### PR TITLE
feat: 커뮤니티 게시판 CRUD API 구현

### DIFF
--- a/src/main/java/com/hambug/Hambug/domain/board/api/BoardApi.java
+++ b/src/main/java/com/hambug/Hambug/domain/board/api/BoardApi.java
@@ -2,35 +2,63 @@ package com.hambug.Hambug.domain.board.api;
 
 import com.hambug.Hambug.domain.board.dto.BoardRequestDTO;
 import com.hambug.Hambug.domain.board.dto.BoardResponseDTO;
+import com.hambug.Hambug.domain.board.entity.Category;
+import com.hambug.Hambug.domain.oauth.entity.PrincipalDetails;
 import com.hambug.Hambug.global.response.CommonResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
-@Tag(name = "게시판 API", description = "게시판 CRUD 관련 API")
+@Tag(name = "게시판 API", description = "커뮤니티 게시판 관리 API")
 public interface BoardApi {
 
-    @Operation(summary = "모든 게시글 조회", description = "모든 게시글을 조회합니다.")
+    @Operation(summary = "게시글 전체 조회", description = "전체 게시글을 조회합니다.")
     CommonResponse<List<BoardResponseDTO.BoardResponse>> getBoards();
 
-    @Operation(summary = "특정 게시글 조회", description = "ID를 통해 특정 게시글을 조회합니다.")
+    @Operation(summary = "카테고리별 게시글 조회", description = "카테고리별로 게시글을 조회합니다.")
+    CommonResponse<List<BoardResponseDTO.BoardResponse>> getBoardsByCategory(@RequestParam Category category);
+
+    @Operation(summary = "게시글 상세 조회", description = "게시글 ID로 특정 게시글을 조회합니다.")
     CommonResponse<BoardResponseDTO.BoardResponse> getBoard(@PathVariable("id") Long id);
 
     @Operation(summary = "게시글 생성", description = "새로운 게시글을 생성합니다.")
-    CommonResponse<BoardResponseDTO.BoardResponse> createBoard(@RequestBody BoardRequestDTO.BoardCreateRequest request);
+    CommonResponse<BoardResponseDTO.BoardResponse> createBoard(
+            @RequestBody(description = "게시글 생성 요청", required = true,
+                    content = @Content(schema = @Schema(implementation = BoardRequestDTO.BoardCreateRequest.class))) 
+            @org.springframework.web.bind.annotation.RequestBody BoardRequestDTO.BoardCreateRequest request,
+            @AuthenticationPrincipal PrincipalDetails principalDetails);
 
-    @Operation(summary = "게시글 수정", description = "ID를 통해 특정 게시글을 수정합니다.")
+    @Operation(summary = "이미지와 함께 게시글 생성", description = "이미지 파일과 함께 새로운 게시글을 생성합니다.")
+    CommonResponse<BoardResponseDTO.BoardResponse> createBoardWithImages(
+            @RequestPart("request") BoardRequestDTO.BoardCreateRequest request,
+            @RequestPart(value = "images", required = false) List<MultipartFile> images,
+            @AuthenticationPrincipal PrincipalDetails principalDetails);
+
+    @Operation(summary = "게시글 수정", description = "기존 게시글을 수정합니다.")
     CommonResponse<BoardResponseDTO.BoardResponse> updateBoard(
             @PathVariable("id") Long id,
-            @RequestBody BoardRequestDTO.BoardUpdateRequest request);
+            @RequestBody(description = "게시글 수정 요청", required = true,
+                    content = @Content(schema = @Schema(implementation = BoardRequestDTO.BoardUpdateRequest.class)))
+            @org.springframework.web.bind.annotation.RequestBody BoardRequestDTO.BoardUpdateRequest request,
+            @AuthenticationPrincipal PrincipalDetails principalDetails);
 
-    @Operation(summary = "게시글 삭제", description = "ID를 통해 특정 게시글을 삭제합니다.")
-    CommonResponse<Boolean> deleteBoard(@PathVariable("id") Long id);
+    @Operation(summary = "이미지와 함께 게시글 수정", description = "이미지 파일과 함께 기존 게시글을 수정합니다.")
+    CommonResponse<BoardResponseDTO.BoardResponse> updateBoardWithImages(
+            @PathVariable("id") Long id,
+            @RequestPart("request") BoardRequestDTO.BoardUpdateRequest request,
+            @RequestPart(value = "images", required = false) List<MultipartFile> images,
+            @AuthenticationPrincipal PrincipalDetails principalDetails);
+
+    @Operation(summary = "게시글 삭제", description = "게시글을 삭제합니다.")
+    CommonResponse<Boolean> deleteBoard(@PathVariable("id") Long id,
+                                        @AuthenticationPrincipal PrincipalDetails principalDetails);
 }

--- a/src/main/java/com/hambug/Hambug/domain/board/dto/BoardRequestDTO.java
+++ b/src/main/java/com/hambug/Hambug/domain/board/dto/BoardRequestDTO.java
@@ -1,6 +1,10 @@
 package com.hambug.Hambug.domain.board.dto;
 
+import com.hambug.Hambug.domain.board.entity.Category;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
 
 public class BoardRequestDTO {
 
@@ -9,11 +13,18 @@ public class BoardRequestDTO {
             String title,
 
             @NotBlank(message = "내용은 필수 입력 값입니다.")
-            String content
+            String content,
+
+            @NotNull(message = "카테고리는 필수 선택 값입니다.")
+            Category category,
+
+            List<String> imageUrls
     ) {}
 
     public record BoardUpdateRequest(
             String title,
-            String content
+            String content,
+            Category category,
+            List<String> imageUrls
     ) {}
 }

--- a/src/main/java/com/hambug/Hambug/domain/board/dto/BoardResponseDTO.java
+++ b/src/main/java/com/hambug/Hambug/domain/board/dto/BoardResponseDTO.java
@@ -2,8 +2,10 @@ package com.hambug.Hambug.domain.board.dto;
 
 
 import com.hambug.Hambug.domain.board.entity.Board;
+import com.hambug.Hambug.domain.board.entity.Category;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public class BoardResponseDTO {
 
@@ -12,6 +14,10 @@ public class BoardResponseDTO {
             Long id,
             String title,
             String content,
+            Category category,
+            List<String> imageUrls,
+            String authorNickname,
+            Long authorId,
             LocalDateTime createdAt,
             LocalDateTime updatedAt
     ) {
@@ -20,6 +26,10 @@ public class BoardResponseDTO {
                     board.getId(),
                     board.getTitle(),
                     board.getContent(),
+                    board.getCategory(),
+                    board.getImageUrls(),
+                    board.getUser().getNickname(),
+                    board.getUser().getId(),
                     board.getCreatedAt(),
                     board.getModifiedAt()
             );

--- a/src/main/java/com/hambug/Hambug/domain/board/entity/Board.java
+++ b/src/main/java/com/hambug/Hambug/domain/board/entity/Board.java
@@ -1,10 +1,14 @@
 package com.hambug.Hambug.domain.board.entity;
 
 
+import com.hambug.Hambug.domain.user.entity.User;
 import com.hambug.Hambug.global.timeStamped.Timestamped;
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 @Entity
 @Getter
@@ -21,13 +25,32 @@ public class Board extends Timestamped {
     @Column(nullable = false, columnDefinition = "TEXT")
     private String content;
 
-    public Board(String title, String content) {
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Category category;
+
+    @ElementCollection
+    @CollectionTable(name = "board_images", joinColumns = @JoinColumn(name = "board_id"))
+    @Column(name = "image_url")
+    private List<String> imageUrls;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Builder
+    public Board(String title, String content, Category category, List<String> imageUrls, User user) {
         this.title = title;
         this.content = content;
+        this.category = category;
+        this.imageUrls = imageUrls;
+        this.user = user;
     }
 
-    public void update(String title, String content) {
+    public void update(String title, String content, Category category, List<String> imageUrls) {
         this.title = title;
         this.content = content;
+        this.category = category;
+        this.imageUrls = imageUrls;
     }
 }

--- a/src/main/java/com/hambug/Hambug/domain/board/repository/BoardRepository.java
+++ b/src/main/java/com/hambug/Hambug/domain/board/repository/BoardRepository.java
@@ -1,7 +1,14 @@
 package com.hambug.Hambug.domain.board.repository;
 
 import com.hambug.Hambug.domain.board.entity.Board;
+import com.hambug.Hambug.domain.board.entity.Category;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface BoardRepository extends JpaRepository<Board, Long> {
+    
+    List<Board> findByCategory(Category category);
+    List<Board> findByOrderByCreatedAtDesc();
+    List<Board> findByCategoryOrderByCreatedAtDesc(Category category);
 }

--- a/src/main/java/com/hambug/Hambug/domain/board/service/BoardService.java
+++ b/src/main/java/com/hambug/Hambug/domain/board/service/BoardService.java
@@ -4,13 +4,21 @@ package com.hambug.Hambug.domain.board.service;
 import com.hambug.Hambug.domain.board.dto.BoardRequestDTO;
 import com.hambug.Hambug.domain.board.dto.BoardResponseDTO;
 import com.hambug.Hambug.domain.board.entity.Board;
+import com.hambug.Hambug.domain.board.entity.Category;
+import com.hambug.Hambug.domain.board.exception.BoardNotFoundException;
+import com.hambug.Hambug.domain.board.exception.UnauthorizedBoardAccessException;
 import com.hambug.Hambug.domain.board.repository.BoardRepository;
-import jakarta.persistence.EntityNotFoundException;
+import com.hambug.Hambug.domain.user.entity.User;
+import com.hambug.Hambug.domain.user.repository.UserRepository;
+import com.hambug.Hambug.global.response.ErrorCode;
+import com.hambug.Hambug.global.s3.service.S3Service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -20,6 +28,8 @@ import java.util.stream.Collectors;
 public class BoardService {
 
     private final BoardRepository boardRepository;
+    private final UserRepository userRepository;
+    private final S3Service s3Service;
 
     public List<BoardResponseDTO.BoardResponse> findAllBoards() {
         return boardRepository.findAll().stream()
@@ -27,32 +37,119 @@ public class BoardService {
                 .collect(Collectors.toList());
     }
 
+    public List<BoardResponseDTO.BoardResponse> findBoardsByCategory(Category category) {
+        return boardRepository.findByCategory(category).stream()
+                .map(BoardResponseDTO.BoardResponse::new)
+                .collect(Collectors.toList());
+    }
+
     public BoardResponseDTO.BoardResponse findBoardById(Long id) {
         Board board = boardRepository.findById(id)
-                .orElseThrow(() -> new EntityNotFoundException("게시글을 찾을 수 없습니다."));
+                .orElseThrow(() -> new BoardNotFoundException(ErrorCode.BOARD_NOT_FOUND));
         return new BoardResponseDTO.BoardResponse(board);
     }
 
-    @Transactional // 쓰기 작업에 대한 트랜잭션
-    public BoardResponseDTO.BoardResponse createBoard(BoardRequestDTO.BoardCreateRequest request) {
-        Board board = new Board(request.title(), request.content());
+    @Transactional
+    public BoardResponseDTO.BoardResponse createBoard(BoardRequestDTO.BoardCreateRequest request, Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."));
+
+        Board board = Board.builder()
+                .title(request.title())
+                .content(request.content())
+                .category(request.category())
+                .imageUrls(request.imageUrls())
+                .user(user)
+                .build();
+        
         boardRepository.save(board);
         return new BoardResponseDTO.BoardResponse(board);
     }
 
     @Transactional
-    public BoardResponseDTO.BoardResponse updateBoard(Long id, BoardRequestDTO.BoardUpdateRequest request) {
-        Board board = boardRepository.findById(id)
-                .orElseThrow(() -> new EntityNotFoundException("게시글을 찾을 수 없습니다."));
+    public BoardResponseDTO.BoardResponse createBoardWithImages(BoardRequestDTO.BoardCreateRequest request, 
+                                                               List<MultipartFile> images, Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."));
 
-        board.update(request.title(),  request.content());
+        List<String> imageUrls = new ArrayList<>();
+        if (images != null && !images.isEmpty()) {
+            if (images.size() > 5) {
+                throw new IllegalArgumentException("이미지는 최대 5장까지 업로드 가능합니다.");
+            }
+            for (MultipartFile image : images) {
+                try {
+                    String imageUrl = s3Service.uploadImage(image);
+                    imageUrls.add(imageUrl);
+                } catch (Exception e) {
+                    throw new RuntimeException("이미지 업로드에 실패했습니다.", e);
+                }
+            }
+        }
+
+        Board board = Board.builder()
+                .title(request.title())
+                .content(request.content())
+                .category(request.category())
+                .imageUrls(imageUrls)
+                .user(user)
+                .build();
+        
+        boardRepository.save(board);
         return new BoardResponseDTO.BoardResponse(board);
     }
 
     @Transactional
-    public void deleteBoard(Long id) {
+    public BoardResponseDTO.BoardResponse updateBoard(Long id, BoardRequestDTO.BoardUpdateRequest request, Long userId) {
         Board board = boardRepository.findById(id)
-                .orElseThrow(() -> new EntityNotFoundException("게시글을 찾을 수 없습니다."));
+                .orElseThrow(() -> new BoardNotFoundException(ErrorCode.BOARD_NOT_FOUND));
+
+        if (!board.getUser().getId().equals(userId)) {
+            throw new UnauthorizedBoardAccessException(ErrorCode.UNAUTHORIZED_BOARD_ACCESS);
+        }
+
+        board.update(request.title(), request.content(), request.category(), request.imageUrls());
+        return new BoardResponseDTO.BoardResponse(board);
+    }
+
+    @Transactional
+    public BoardResponseDTO.BoardResponse updateBoardWithImages(Long id, BoardRequestDTO.BoardUpdateRequest request, 
+                                                               List<MultipartFile> images, Long userId) {
+        Board board = boardRepository.findById(id)
+                .orElseThrow(() -> new BoardNotFoundException(ErrorCode.BOARD_NOT_FOUND));
+
+        if (!board.getUser().getId().equals(userId)) {
+            throw new UnauthorizedBoardAccessException(ErrorCode.UNAUTHORIZED_BOARD_ACCESS);
+        }
+
+        List<String> imageUrls = new ArrayList<>();
+        if (images != null && !images.isEmpty()) {
+            if (images.size() > 5) {
+                throw new IllegalArgumentException("이미지는 최대 5장까지 업로드 가능합니다.");
+            }
+            for (MultipartFile image : images) {
+                try {
+                    String imageUrl = s3Service.uploadImage(image);
+                    imageUrls.add(imageUrl);
+                } catch (Exception e) {
+                    throw new RuntimeException("이미지 업로드에 실패했습니다.", e);
+                }
+            }
+        }
+
+        board.update(request.title(), request.content(), request.category(), imageUrls);
+        return new BoardResponseDTO.BoardResponse(board);
+    }
+
+    @Transactional
+    public void deleteBoard(Long id, Long userId) {
+        Board board = boardRepository.findById(id)
+                .orElseThrow(() -> new BoardNotFoundException(ErrorCode.BOARD_NOT_FOUND));
+
+        if (!board.getUser().getId().equals(userId)) {
+            throw new UnauthorizedBoardAccessException(ErrorCode.UNAUTHORIZED_BOARD_ACCESS);
+        }
+
         boardRepository.delete(board);
     }
 }

--- a/src/main/java/com/hambug/Hambug/global/response/ErrorCode.java
+++ b/src/main/java/com/hambug/Hambug/global/response/ErrorCode.java
@@ -10,6 +10,8 @@ public enum ErrorCode {
     JWT_TOKEN_MISSING("J003", "JWT 토큰이 누락되었습니다."),
     NOT_FOUND_ENTITY("COM001", "해당 엔티티를 찾을수 없습니다."),
     ALREADY_ENTITY("COM002", "해당 엔티티는 이미 존재합니다."),
+    BOARD_NOT_FOUND("B001", "게시글을 찾을 수 없습니다."),
+    UNAUTHORIZED_BOARD_ACCESS("B002", "게시글에 대한 권한이 없습니다."),
     SERVER_ERROR("S001", "서버 오류가 발생했습니다.");
 
     private final String code;


### PR DESCRIPTION
● Board CRUD 구현 - 커뮤니티 게시판 기능 추가

  개요

  기획 요구사항에 맞춘 커뮤니티 게시판 CRUD API 구현
  - 4가지 카테고리 (자유잡담, 프렌차이즈, 수제버거, 맛집추천)
  - 이미지 업로드 (최대 5장)
  - 사용자 인증 기반 작성/수정/삭제

  주요 변경사항

  Entity & Repository

  - Board 엔티티: 카테고리, 이미지URL 목록, 작성자 연관관계 추가
  - Category enum: 4가지 커뮤니티 카테고리 정의
  - BoardRepository: 카테고리별 조회, 최신순 정렬 쿼리 메서드 추가

  API & Service

  - BoardApi: Swagger 문서화 및 인증 기반 API 스펙
  - BoardService: 이미지 업로드, 권한 검증, 카테고리 필터링 로직
  - BoardController: 일반/이미지 업로드용 분리된 엔드포인트

  DTO & Exception

  - BoardRequestDTO: 카테고리, 이미지URL 필드 추가
  - BoardResponseDTO: 작성자 정보, 카테고리, 이미지 목록 포함
  - BoardNotFoundException, UnauthorizedBoardAccessException: 도메인별 예외 처리

  API 엔드포인트

  조회

  - GET /api/v1/boards - 전체 게시글 조회
  - GET /api/v1/boards/category?category={CATEGORY} - 카테고리별 조회
  - GET /api/v1/boards/{id} - 게시글 상세 조회

  생성/수정

  - POST /api/v1/boards - 일반 게시글 생성
  - POST /api/v1/boards/with-images - 이미지 포함 게시글 생성
  - PUT /api/v1/boards/{id} - 게시글 수정
  - PUT /api/v1/boards/{id}/with-images - 이미지 포함 수정

  삭제

  - DELETE /api/v1/boards/{id} - 게시글 삭제 (작성자 본인만 가능)

  보안 & 검증

  - @AuthenticationPrincipal을 통한 작성자 인증
  - 수정/삭제 시 작성자 권한 검증
  - 이미지 업로드 최대 5장 제한
  - @NotBlank, @NotNull validation 적용

