### PR TITLE
커뮤니티 댓글·신고 기능 

### DIFF
--- a/src/main/java/com/hambug/Hambug/domain/auth/service/JwtService.java
+++ b/src/main/java/com/hambug/Hambug/domain/auth/service/JwtService.java
@@ -27,8 +27,8 @@ import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
 
-import static com.hambug.Hambug.global.response.ErrorCode.JWT_TOKEN_EXPIRED;
-import static com.hambug.Hambug.global.response.ErrorCode.JWT_TOKEN_INVALID;
+import static com.hambug.Hambug.global.exception.ErrorCode.JWT_TOKEN_EXPIRED;
+import static com.hambug.Hambug.global.exception.ErrorCode.JWT_TOKEN_INVALID;
 
 @Slf4j
 @Service

--- a/src/main/java/com/hambug/Hambug/domain/board/entity/Category.java
+++ b/src/main/java/com/hambug/Hambug/domain/board/entity/Category.java
@@ -1,0 +1,17 @@
+package com.hambug.Hambug.domain.board.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum Category {
+    FREE_TALK("자유잡담"),
+    FRANCHISE("프랜차이즈"),
+    HANDMADE("수제버거"),
+    RECOMMENDATION("맛집추천");
+
+    private final String description;
+
+    Category(String description) {
+        this.description = description;
+    }
+}

--- a/src/main/java/com/hambug/Hambug/domain/board/exception/BoardNotFoundException.java
+++ b/src/main/java/com/hambug/Hambug/domain/board/exception/BoardNotFoundException.java
@@ -1,19 +1,19 @@
-package com.hambug.Hambug.global.exception.custom;
+package com.hambug.Hambug.domain.board.exception;
 
 import com.hambug.Hambug.global.exception.ErrorCode;
 import lombok.Getter;
 
 @Getter
-public class JwtException extends RuntimeException {
+public class BoardNotFoundException extends RuntimeException {
 
     private final ErrorCode errorCode;
 
-    public JwtException(ErrorCode errorCode) {
+    public BoardNotFoundException(ErrorCode errorCode) {
         super(errorCode.getMessage());
         this.errorCode = errorCode;
     }
 
-    public JwtException(ErrorCode errorCode, String message) {
+    public BoardNotFoundException(ErrorCode errorCode, String message) {
         super(message);
         this.errorCode = errorCode;
     }

--- a/src/main/java/com/hambug/Hambug/domain/board/exception/UnauthorizedBoardAccessException.java
+++ b/src/main/java/com/hambug/Hambug/domain/board/exception/UnauthorizedBoardAccessException.java
@@ -1,0 +1,20 @@
+package com.hambug.Hambug.domain.board.exception;
+
+import com.hambug.Hambug.global.exception.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class UnauthorizedBoardAccessException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public UnauthorizedBoardAccessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public UnauthorizedBoardAccessException(ErrorCode errorCode, String message) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/hambug/Hambug/domain/comment/api/CommentApi.java
+++ b/src/main/java/com/hambug/Hambug/domain/comment/api/CommentApi.java
@@ -1,0 +1,34 @@
+package com.hambug.Hambug.domain.comment.api;
+
+import com.hambug.Hambug.domain.comment.dto.CommentRequestDTO;
+import com.hambug.Hambug.domain.comment.dto.CommentResponseDTO;
+import com.hambug.Hambug.global.response.CommonResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import java.util.List;
+
+@Tag(name = "댓글 API", description = "댓글 CRUD 관련 API")
+public interface CommentApi {
+
+    @Operation(summary = "댓글 목록 조회", description = "게시글 ID로 댓글 목록을 조회합니다.")
+    CommonResponse<List<CommentResponseDTO.CommentResponse>> getComments(@PathVariable("boardId") Long boardId);
+
+    @Operation(summary = "댓글 생성", description = "게시글에 새로운 댓글을 생성합니다.")
+    CommonResponse<CommentResponseDTO.CommentResponse> createComment(
+            @PathVariable("boardId") Long boardId,
+            @RequestBody CommentRequestDTO.CommentCreateRequest request);
+
+    @Operation(summary = "댓글 수정", description = "댓글 ID로 특정 댓글을 수정합니다.")
+    CommonResponse<CommentResponseDTO.CommentResponse> updateComment(
+            @PathVariable("boardId") Long boardId,
+            @PathVariable("commentId") Long commentId,
+            @RequestBody CommentRequestDTO.CommentUpdateRequest request);
+
+    @Operation(summary = "댓글 삭제", description = "댓글 ID로 특정 댓글을 삭제합니다.")
+    CommonResponse<Boolean> deleteComment(
+            @PathVariable("boardId") Long boardId,
+            @PathVariable("commentId") Long commentId);
+}

--- a/src/main/java/com/hambug/Hambug/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/hambug/Hambug/domain/comment/controller/CommentController.java
@@ -1,0 +1,63 @@
+package com.hambug.Hambug.domain.comment.controller;
+
+import com.hambug.Hambug.domain.comment.api.CommentApi;
+import com.hambug.Hambug.domain.comment.dto.CommentRequestDTO;
+import com.hambug.Hambug.domain.comment.dto.CommentResponseDTO;
+import com.hambug.Hambug.domain.comment.service.CommentService;
+import com.hambug.Hambug.global.response.CommonResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/boards/{boardId}/comments")
+public class CommentController implements CommentApi {
+
+    private final CommentService commentService;
+
+    @Override
+    @GetMapping
+    public CommonResponse<List<CommentResponseDTO.CommentResponse>> getComments(@PathVariable("boardId") Long boardId) {
+        List<CommentResponseDTO.CommentResponse> comments = commentService.findCommentsByBoard(boardId);
+        return CommonResponse.ok(comments);
+    }
+
+    @Override
+    @PostMapping
+    public CommonResponse<CommentResponseDTO.CommentResponse> createComment(
+            @PathVariable("boardId") Long boardId,
+            @RequestBody CommentRequestDTO.CommentCreateRequest request) {
+        CommentResponseDTO.CommentResponse comment = commentService.createComment(boardId, request);
+        return CommonResponse.ok(comment);
+    }
+
+    @Override
+    @PutMapping("/{commentId}")
+    public CommonResponse<CommentResponseDTO.CommentResponse> updateComment(
+            @PathVariable("boardId") Long boardId,
+            @PathVariable("commentId") Long commentId,
+            @RequestBody CommentRequestDTO.CommentUpdateRequest request) {
+        CommentResponseDTO.CommentResponse updatedComment = commentService.updateComment(boardId, commentId, request);
+        return CommonResponse.ok(updatedComment);
+    }
+
+    @Override
+    @DeleteMapping("/{commentId}")
+    public CommonResponse<Boolean> deleteComment(
+            @PathVariable("boardId") Long boardId,
+            @PathVariable("commentId") Long commentId) {
+        commentService.deleteComment(boardId, commentId);
+        return CommonResponse.ok(true);
+    }
+}

--- a/src/main/java/com/hambug/Hambug/domain/comment/dto/CommentRequestDTO.java
+++ b/src/main/java/com/hambug/Hambug/domain/comment/dto/CommentRequestDTO.java
@@ -1,0 +1,10 @@
+package com.hambug.Hambug.domain.comment.dto;
+
+public class CommentRequestDTO {
+
+    public record CommentCreateRequest(String content) {
+    }
+
+    public record CommentUpdateRequest(String content) {
+    }
+}

--- a/src/main/java/com/hambug/Hambug/domain/comment/dto/CommentResponseDTO.java
+++ b/src/main/java/com/hambug/Hambug/domain/comment/dto/CommentResponseDTO.java
@@ -1,0 +1,23 @@
+package com.hambug.Hambug.domain.comment.dto;
+
+import com.hambug.Hambug.domain.comment.entity.Comment;
+import java.time.LocalDateTime;
+
+public class CommentResponseDTO {
+
+    public record CommentResponse(
+            Long id,
+            String content,
+            LocalDateTime createdAt,
+            LocalDateTime updatedAt
+    ) {
+        public CommentResponse(Comment comment) {
+            this(
+                    comment.getId(),
+                    comment.getContent(),
+                    comment.getCreatedAt(),
+                    comment.getModifiedAt()
+            );
+        }
+    }
+}

--- a/src/main/java/com/hambug/Hambug/domain/comment/entity/Comment.java
+++ b/src/main/java/com/hambug/Hambug/domain/comment/entity/Comment.java
@@ -1,0 +1,33 @@
+package com.hambug.Hambug.domain.comment.entity;
+
+import com.hambug.Hambug.domain.board.entity.Board;
+import com.hambug.Hambug.global.timeStamped.Timestamped;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Comment extends Timestamped {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "board_id", nullable = false)
+    private Board board;
+
+    public Comment(String content, Board board) {
+        this.content = content;
+        this.board = board;
+    }
+
+    public void update(String content) {
+        this.content = content;
+    }
+}

--- a/src/main/java/com/hambug/Hambug/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/hambug/Hambug/domain/comment/repository/CommentRepository.java
@@ -1,0 +1,11 @@
+package com.hambug.Hambug.domain.comment.repository;
+
+import com.hambug.Hambug.domain.comment.entity.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+    List<Comment> findAllByBoardId(Long boardId);
+}

--- a/src/main/java/com/hambug/Hambug/domain/comment/service/CommentService.java
+++ b/src/main/java/com/hambug/Hambug/domain/comment/service/CommentService.java
@@ -1,0 +1,80 @@
+package com.hambug.Hambug.domain.comment.service;
+
+import com.hambug.Hambug.domain.board.entity.Board;
+import com.hambug.Hambug.domain.board.repository.BoardRepository;
+import com.hambug.Hambug.domain.comment.dto.CommentRequestDTO;
+import com.hambug.Hambug.domain.comment.dto.CommentResponseDTO;
+import com.hambug.Hambug.domain.comment.entity.Comment;
+import com.hambug.Hambug.domain.comment.repository.CommentRepository;
+import com.hambug.Hambug.global.exception.custom.NotFoundException;
+import com.hambug.Hambug.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@Slf4j
+@Service
+public class CommentService {
+
+    private final CommentRepository commentRepository;
+    private final BoardRepository boardRepository;
+
+    @Transactional(readOnly = true)
+    public List<CommentResponseDTO.CommentResponse> findCommentsByBoard(Long boardId) {
+        validateBoard(boardId);
+        return commentRepository.findAllByBoardId(boardId).stream()
+                .map(CommentResponseDTO.CommentResponse::new)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public CommentResponseDTO.CommentResponse createComment(Long boardId, CommentRequestDTO.CommentCreateRequest request) {
+        Board board = findBoard(boardId);
+        Comment comment = new Comment(request.content(), board);
+        commentRepository.save(comment);
+        return new CommentResponseDTO.CommentResponse(comment);
+    }
+
+    @Transactional
+    public CommentResponseDTO.CommentResponse updateComment(Long boardId, Long commentId, CommentRequestDTO.CommentUpdateRequest request) {
+        Comment comment = findComment(commentId);
+        validateCommentBoard(comment, boardId);
+
+        comment.update(request.content());
+        return new CommentResponseDTO.CommentResponse(comment);
+    }
+
+    @Transactional
+    public void deleteComment(Long boardId, Long commentId) {
+        Comment comment = findComment(commentId);
+        validateCommentBoard(comment, boardId);
+        commentRepository.delete(comment);
+    }
+
+    private void validateBoard(Long boardId) {
+        if (!boardRepository.existsById(boardId)) {
+            throw new NotFoundException(ErrorCode.BOARD_NOT_FOUND);
+        }
+    }
+
+    private Board findBoard(Long boardId) {
+        return boardRepository.findById(boardId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.BOARD_NOT_FOUND));
+    }
+
+    private Comment findComment(Long commentId) {
+        return commentRepository.findById(commentId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.COMMENT_NOT_FOUND));
+    }
+
+    private void validateCommentBoard(Comment comment, Long boardId) {
+        if (!comment.getBoard().getId().equals(boardId)) {
+            throw new NotFoundException(ErrorCode.COMMENT_BOARD_MISMATCH);
+        }
+    }
+}

--- a/src/main/java/com/hambug/Hambug/domain/report/api/ReportApi.java
+++ b/src/main/java/com/hambug/Hambug/domain/report/api/ReportApi.java
@@ -1,0 +1,21 @@
+package com.hambug.Hambug.domain.report.api;
+
+import com.hambug.Hambug.domain.oauth.entity.PrincipalDetails;
+import com.hambug.Hambug.domain.report.dto.ReportRequestDTO;
+import com.hambug.Hambug.global.response.CommonResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import jakarta.validation.Valid;
+
+@Tag(name = "신고 API", description = "게시글/댓글 신고 관련 API")
+public interface ReportApi {
+
+    @Operation(summary = "게시글/댓글 신고", description = "게시글 또는 댓글을 신고합니다.")
+    @PostMapping
+    CommonResponse<Void> createReport(@AuthenticationPrincipal PrincipalDetails principalDetails,
+                                      @Valid @RequestBody ReportRequestDTO.CreateReport request);
+}

--- a/src/main/java/com/hambug/Hambug/domain/report/controller/ReportController.java
+++ b/src/main/java/com/hambug/Hambug/domain/report/controller/ReportController.java
@@ -1,0 +1,37 @@
+package com.hambug.Hambug.domain.report.controller;
+
+import com.hambug.Hambug.domain.oauth.entity.PrincipalDetails;
+import com.hambug.Hambug.domain.report.api.ReportApi;
+import com.hambug.Hambug.domain.report.dto.ReportRequestDTO;
+import com.hambug.Hambug.domain.report.service.ReportService;
+import com.hambug.Hambug.global.response.CommonResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.Valid;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/reports")
+public class ReportController implements ReportApi {
+
+    private final ReportService reportService;
+
+    @Override
+    public CommonResponse<Void> createReport(@AuthenticationPrincipal PrincipalDetails principalDetails,
+                                             @Valid @RequestBody ReportRequestDTO.CreateReport request) {
+        Long userId = getUserId(principalDetails);
+        reportService.createReport(userId, request);
+        return CommonResponse.ok(null);
+    }
+
+    private Long getUserId(PrincipalDetails principalDetails) {
+        if (principalDetails == null || principalDetails.getUserDto() == null) {
+            throw new IllegalStateException("인증 정보가 존재하지 않습니다.");
+        }
+        return principalDetails.getUserDto().getUserId();
+    }
+}

--- a/src/main/java/com/hambug/Hambug/domain/report/dto/ReportRequestDTO.java
+++ b/src/main/java/com/hambug/Hambug/domain/report/dto/ReportRequestDTO.java
@@ -1,0 +1,19 @@
+package com.hambug.Hambug.domain.report.dto;
+
+import com.hambug.Hambug.domain.report.entity.TargetType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public class ReportRequestDTO {
+
+    public record CreateReport(
+            @NotNull(message = "신고 대상 ID는 필수입니다.")
+            Long targetId,
+
+            @NotNull(message = "신고 대상 타입은 필수입니다.")
+            TargetType targetType,
+
+            @NotBlank(message = "신고 사유는 필수입니다.")
+            String reason
+    ) {}
+}

--- a/src/main/java/com/hambug/Hambug/domain/report/entity/Report.java
+++ b/src/main/java/com/hambug/Hambug/domain/report/entity/Report.java
@@ -1,0 +1,36 @@
+package com.hambug.Hambug.domain.report.entity;
+
+import com.hambug.Hambug.global.timeStamped.Timestamped;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Report extends Timestamped {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long userId; // 신고한 사용자 ID
+
+    @Column(nullable = false)
+    private Long targetId; // 신고된 게시글 또는 댓글 ID
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private TargetType targetType; // 신고된 대상의 타입
+
+    @Column(nullable = false)
+    private String reason; // 신고 사유
+
+    public Report(Long userId, Long targetId, TargetType targetType, String reason) {
+        this.userId = userId;
+        this.targetId = targetId;
+        this.targetType = targetType;
+        this.reason = reason;
+    }
+}

--- a/src/main/java/com/hambug/Hambug/domain/report/entity/TargetType.java
+++ b/src/main/java/com/hambug/Hambug/domain/report/entity/TargetType.java
@@ -1,0 +1,6 @@
+package com.hambug.Hambug.domain.report.entity;
+
+public enum TargetType {
+    BOARD, // 게시글
+    COMMENT // 댓글
+}

--- a/src/main/java/com/hambug/Hambug/domain/report/repository/ReportRepository.java
+++ b/src/main/java/com/hambug/Hambug/domain/report/repository/ReportRepository.java
@@ -1,0 +1,7 @@
+package com.hambug.Hambug.domain.report.repository;
+
+import com.hambug.Hambug.domain.report.entity.Report;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReportRepository extends JpaRepository<Report, Long> {
+}

--- a/src/main/java/com/hambug/Hambug/domain/report/service/ReportService.java
+++ b/src/main/java/com/hambug/Hambug/domain/report/service/ReportService.java
@@ -1,0 +1,56 @@
+package com.hambug.Hambug.domain.report.service;
+
+import com.hambug.Hambug.domain.board.repository.BoardRepository;
+import com.hambug.Hambug.domain.comment.repository.CommentRepository;
+import com.hambug.Hambug.domain.report.dto.ReportRequestDTO;
+import com.hambug.Hambug.domain.report.entity.Report;
+import com.hambug.Hambug.domain.report.entity.TargetType;
+import com.hambug.Hambug.domain.report.repository.ReportRepository;
+import com.hambug.Hambug.global.exception.ErrorCode;
+import com.hambug.Hambug.global.exception.custom.NotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ReportService {
+
+    private final ReportRepository reportRepository;
+    private final BoardRepository boardRepository;
+    private final CommentRepository commentRepository;
+
+    @Transactional
+    public void createReport(Long userId, ReportRequestDTO.CreateReport request) {
+        validateTarget(request.targetId(), request.targetType());
+
+        Report report = new Report(
+                userId,
+                request.targetId(),
+                request.targetType(),
+                request.reason()
+        );
+
+        reportRepository.save(report);
+    }
+
+    private void validateTarget(Long targetId, TargetType targetType) {
+        switch (targetType) {
+            case BOARD -> validateBoard(targetId);
+            case COMMENT -> validateComment(targetId);
+            default -> throw new IllegalArgumentException("Unsupported report target type: " + targetType);
+        }
+    }
+
+    private void validateBoard(Long targetId) {
+        if (!boardRepository.existsById(targetId)) {
+            throw new NotFoundException(ErrorCode.BOARD_NOT_FOUND);
+        }
+    }
+
+    private void validateComment(Long targetId) {
+        if (!commentRepository.existsById(targetId)) {
+            throw new NotFoundException(ErrorCode.COMMENT_NOT_FOUND);
+        }
+    }
+}

--- a/src/main/java/com/hambug/Hambug/domain/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/hambug/Hambug/domain/user/service/impl/UserServiceImpl.java
@@ -9,7 +9,7 @@ import com.hambug.Hambug.domain.user.repository.UserRepository;
 import com.hambug.Hambug.domain.user.service.UserService;
 import com.hambug.Hambug.global.exception.custom.AlreadyEntityException;
 import com.hambug.Hambug.global.exception.custom.JwtException;
-import com.hambug.Hambug.global.response.ErrorCode;
+import com.hambug.Hambug.global.exception.ErrorCode;
 import com.hambug.Hambug.global.s3.service.S3Service;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/hambug/Hambug/global/exception/ErrorCode.java
+++ b/src/main/java/com/hambug/Hambug/global/exception/ErrorCode.java
@@ -1,0 +1,25 @@
+package com.hambug.Hambug.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public enum ErrorCode {
+
+    JWT_TOKEN_INVALID("J001", "유효하지 않은 JWT 토큰입니다."),
+    JWT_TOKEN_EXPIRED("J002", "만료된 JWT 토큰입니다."),
+    JWT_TOKEN_MISSING("J003", "JWT 토큰이 존재하지 않습니다."),
+    NOT_FOUND_ENTITY("COM001", "해당 데이터를 찾을 수 없습니다."),
+    ALREADY_ENTITY("COM002", "이미 존재하는 데이터입니다."),
+    SERVER_ERROR("S001", "서버 오류가 발생했습니다."),
+    BOARD_NOT_FOUND("B001", "게시글을 찾을 수 없습니다."),
+    COMMENT_NOT_FOUND("C001", "댓글을 찾을 수 없습니다."),
+    COMMENT_BOARD_MISMATCH("C002", "게시글과 댓글 정보가 일치하지 않습니다.");
+
+    private final String code;
+    private final String message;
+
+    ErrorCode(String code, String message) {
+        this.code = code;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/hambug/Hambug/global/exception/ErrorResponse.java
+++ b/src/main/java/com/hambug/Hambug/global/exception/ErrorResponse.java
@@ -1,6 +1,7 @@
-package com.hambug.Hambug.global.response;
+package com.hambug.Hambug.global.exception;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.hambug.Hambug.global.exception.ErrorCode;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/com/hambug/Hambug/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/hambug/Hambug/global/exception/GlobalExceptionHandler.java
@@ -2,8 +2,9 @@ package com.hambug.Hambug.global.exception;
 
 import com.hambug.Hambug.global.exception.custom.AlreadyEntityException;
 import com.hambug.Hambug.global.exception.custom.JwtException;
-import com.hambug.Hambug.global.response.ErrorCode;
-import com.hambug.Hambug.global.response.ErrorResponse;
+import com.hambug.Hambug.global.exception.custom.NotFoundException;
+import com.hambug.Hambug.global.exception.ErrorCode;
+import com.hambug.Hambug.global.exception.ErrorResponse;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -19,6 +20,12 @@ public class GlobalExceptionHandler {
     protected ResponseEntity<ErrorResponse> handleJwtException(JwtException e) {
         ErrorResponse errorResponse = ErrorResponse.of(e.getErrorCode(), e.getMessage());
         return new ResponseEntity<>(errorResponse, HttpStatus.UNAUTHORIZED);
+    }
+
+    @ExceptionHandler(NotFoundException.class)
+    protected ResponseEntity<ErrorResponse> handleNotFoundException(NotFoundException e) {
+        ErrorResponse response = ErrorResponse.of(e.getErrorCode(), e.getMessage());
+        return new ResponseEntity<>(response, HttpStatus.NOT_FOUND);
     }
 
     @ExceptionHandler(EntityNotFoundException.class)

--- a/src/main/java/com/hambug/Hambug/global/exception/custom/AlreadyEntityException.java
+++ b/src/main/java/com/hambug/Hambug/global/exception/custom/AlreadyEntityException.java
@@ -1,6 +1,6 @@
 package com.hambug.Hambug.global.exception.custom;
 
-import com.hambug.Hambug.global.response.ErrorCode;
+import com.hambug.Hambug.global.exception.ErrorCode;
 import lombok.Getter;
 
 @Getter

--- a/src/main/java/com/hambug/Hambug/global/exception/custom/NotFoundException.java
+++ b/src/main/java/com/hambug/Hambug/global/exception/custom/NotFoundException.java
@@ -4,16 +4,16 @@ import com.hambug.Hambug.global.exception.ErrorCode;
 import lombok.Getter;
 
 @Getter
-public class JwtException extends RuntimeException {
+public class NotFoundException extends RuntimeException {
 
     private final ErrorCode errorCode;
 
-    public JwtException(ErrorCode errorCode) {
+    public NotFoundException(ErrorCode errorCode) {
         super(errorCode.getMessage());
         this.errorCode = errorCode;
     }
 
-    public JwtException(ErrorCode errorCode, String message) {
+    public NotFoundException(ErrorCode errorCode, String message) {
         super(message);
         this.errorCode = errorCode;
     }

--- a/src/main/java/com/hambug/Hambug/global/security/JwtExceptionFilter.java
+++ b/src/main/java/com/hambug/Hambug/global/security/JwtExceptionFilter.java
@@ -1,6 +1,6 @@
 package com.hambug.Hambug.global.security;
 
-import com.hambug.Hambug.global.response.ErrorCode;
+import com.hambug.Hambug.global.exception.ErrorCode;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 import jakarta.persistence.EntityNotFoundException;

--- a/src/main/java/com/hambug/Hambug/global/security/SecurityResponseHandler.java
+++ b/src/main/java/com/hambug/Hambug/global/security/SecurityResponseHandler.java
@@ -1,8 +1,8 @@
 package com.hambug.Hambug.global.security;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.hambug.Hambug.global.response.ErrorCode;
-import com.hambug.Hambug.global.response.ErrorResponse;
+import com.hambug.Hambug.global.exception.ErrorCode;
+import com.hambug.Hambug.global.exception.ErrorResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -39,5 +39,4 @@ public class SecurityResponseHandler {
 
         objectMapper.writeValue(response.getWriter(), errorResponse);
     }
-
 }


### PR DESCRIPTION
 커뮤니티 댓글·신고 기능 보완 - 권한·검증 기반 운영

  개요
  커뮤니티 댓글 CRUD API 신설과 신고 기능 보완을 통해 사용자 인증·검증 흐름을 강화하고, 전역 에러 코드/응답 체계를 정비했습니다.

  주요 변경사항

  댓글 API

  - /api/v1/boards/{boardId}/comments 경로에 댓글 목록 조회, 생성, 수정, 삭제 엔드포인트 구현
  - CommentRequestDTO 신설 및 CommentRepository에 findAllByBoardId 추가로 게시글별 댓글 관리
  - CommentService에서 NotFoundException/ErrorCode를 활용해 게시글·댓글 존재/소유 검증 처리

  전역 예외 응답

  - global.exception 패키지에 ErrorCode, ErrorResponse, NotFoundException을 구축
  - GlobalExceptionHandler, SecurityResponseHandler 등에서 새 응답 포맷을 사용하도록 정비

  신고 서비스

  - 신고 API에 @AuthenticationPrincipal PrincipalDetails와 @Valid를 적용해 로그인 사용자 ID로 신고 생성
  - ReportService가 게시글·댓글 존재 여부를 확인하고 적절한 에러 코드를 반환하도록 개선

  API 엔드포인트

  - POST /api/v1/reports : JWT 인증 사용자 기반 게시글·댓글 신고
  - GET/POST/PUT/DELETE /api/v1/boards/{boardId}/comments : 댓글 목록 조회 및 CRUD