### PR TITLE
어드민 신고/인증 기능 추가 및 소셜 로그인 리팩토링

### DIFF
--- a/src/main/java/com/hambug/Hambug/domain/admin/api/AdminApi.java
+++ b/src/main/java/com/hambug/Hambug/domain/admin/api/AdminApi.java
@@ -1,0 +1,56 @@
+package com.hambug.Hambug.domain.admin.api;
+
+import com.hambug.Hambug.domain.admin.dto.AdminUserReqDTO;
+import com.hambug.Hambug.domain.admin.dto.AdminUserResponseDto;
+import com.hambug.Hambug.domain.oauth.entity.PrincipalDetails;
+import com.hambug.Hambug.global.response.CommonResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+import static com.hambug.Hambug.domain.admin.dto.AdminUserReqDTO.AdminLogin;
+import static com.hambug.Hambug.domain.admin.dto.AdminUserReqDTO.RegisterAdminUser;
+
+@Tag(name = "관리자 API", description = "관리자 계정 생성, 로그인, 이메일 인증 및 비밀번호 재설정 API")
+public interface AdminApi {
+
+    @Operation(summary = "관리자 계정 생성", description = "슈퍼관리자 계정을 생성합니다.")
+    AdminUserResponseDto.AdminUserResponse createAdminUser(
+            @RequestBody(description = "관리자 생성 요청", required = true,
+                    content = @Content(schema = @Schema(implementation = AdminUserReqDTO.RegisterAdminUser.class)))
+            @org.springframework.web.bind.annotation.RequestBody RegisterAdminUser body);
+
+    @Operation(summary = "매니저 계정 생성", description = "관리자가 매니저 계정을 생성합니다.")
+    AdminUserResponseDto.AdminUserResponse createManagerUser(
+            @RequestBody(description = "매니저 생성 요청", required = true,
+                    content = @Content(schema = @Schema(implementation = AdminUserReqDTO.RegisterAdminUser.class)))
+            @org.springframework.web.bind.annotation.RequestBody RegisterAdminUser body,
+            @AuthenticationPrincipal PrincipalDetails principalDetails);
+
+    @Operation(summary = "관리자 로그인", description = "관리자 로그인을 수행하고 액세스/리프레시 토큰을 반환합니다.")
+    AdminUserResponseDto.AdminLoginResponse login(
+            @RequestBody(description = "관리자 로그인 요청", required = true,
+                    content = @Content(schema = @Schema(implementation = AdminUserReqDTO.AdminLogin.class)))
+            @org.springframework.web.bind.annotation.RequestBody AdminLogin body);
+
+    @Operation(summary = "이메일 인증코드 전송", description = "관리자 이메일로 인증 코드를 전송합니다.")
+    CommonResponse<AdminUserResponseDto.AdminValidSendEmailResponse> sendEmail(
+            @RequestBody(description = "이메일 전송 요청", required = true,
+                    content = @Content(schema = @Schema(implementation = AdminUserReqDTO.AdminValidSendEmail.class)))
+            @org.springframework.web.bind.annotation.RequestBody AdminUserReqDTO.AdminValidSendEmail body);
+
+    @Operation(summary = "이메일 인증 검증", description = "전송된 인증 코드가 유효한지 검증합니다.")
+    CommonResponse<Boolean> verificationEmail(
+            @RequestBody(description = "이메일 인증 검증 요청", required = true,
+                    content = @Content(schema = @Schema(implementation = AdminUserReqDTO.VerificationEmail.class)))
+            @org.springframework.web.bind.annotation.RequestBody AdminUserReqDTO.VerificationEmail body);
+
+    @Operation(summary = "관리자 비밀번호 재설정", description = "관리자 비밀번호를 재설정합니다. 임시 비밀번호 상태가 아니어야 합니다.")
+    CommonResponse<Boolean> resetPassword(
+            @RequestBody(description = "비밀번호 재설정 요청", required = true,
+                    content = @Content(schema = @Schema(implementation = AdminUserReqDTO.ResetPassword.class)))
+            @org.springframework.web.bind.annotation.RequestBody AdminUserReqDTO.ResetPassword body);
+}

--- a/src/main/java/com/hambug/Hambug/domain/admin/api/AdminApi.java
+++ b/src/main/java/com/hambug/Hambug/domain/admin/api/AdminApi.java
@@ -18,13 +18,13 @@ import static com.hambug.Hambug.domain.admin.dto.AdminUserReqDTO.RegisterAdminUs
 public interface AdminApi {
 
     @Operation(summary = "관리자 계정 생성", description = "슈퍼관리자 계정을 생성합니다.")
-    AdminUserResponseDto.AdminUserResponse createAdminUser(
+    CommonResponse<AdminUserResponseDto.AdminUserResponse> createAdminUser(
             @RequestBody(description = "관리자 생성 요청", required = true,
                     content = @Content(schema = @Schema(implementation = AdminUserReqDTO.RegisterAdminUser.class)))
             @org.springframework.web.bind.annotation.RequestBody RegisterAdminUser body);
 
     @Operation(summary = "매니저 계정 생성", description = "관리자가 매니저 계정을 생성합니다.")
-    AdminUserResponseDto.AdminUserResponse createManagerUser(
+    CommonResponse<AdminUserResponseDto.AdminUserResponse> createManagerUser(
             @RequestBody(description = "매니저 생성 요청", required = true,
                     content = @Content(schema = @Schema(implementation = AdminUserReqDTO.RegisterAdminUser.class)))
             @org.springframework.web.bind.annotation.RequestBody RegisterAdminUser body,

--- a/src/main/java/com/hambug/Hambug/domain/admin/api/AdminReportApi.java
+++ b/src/main/java/com/hambug/Hambug/domain/admin/api/AdminReportApi.java
@@ -1,0 +1,23 @@
+package com.hambug.Hambug.domain.admin.api;
+
+import com.hambug.Hambug.domain.admin.dto.AdminReportReqDto;
+import com.hambug.Hambug.domain.admin.dto.AdminReportResponseDto;
+import com.hambug.Hambug.global.response.CommonResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.ModelAttribute;
+
+@Tag(name = "관리자 신고 API", description = "신고된 게시글및 댓글의 대한 검토의 대한 API")
+public interface AdminReportApi {
+
+    @Operation(summary = "신고된 내역 목록 조회", description = "무한 페이지네이션 방식으로 신고 내역을 조회합니다. , type = 1(Board) ,type = 2(Comment)")
+    CommonResponse<AdminReportResponseDto.Page> getReports(@ModelAttribute AdminReportReqDto.AdminReportPageRequest request);
+
+    @Operation(summary = "신고된 타켓 데이터 상세 조회", description = "신고된 타겟 데이터의 대한 상세 조회를 통해 신고 이유를 조회가능합니다.")
+    CommonResponse<AdminReportResponseDto.DetailPage> getReport(Long id, @ModelAttribute AdminReportReqDto.AdminReportPageRequest request);
+
+    @Operation(summary = "신고된 타켓 데이터 삭제", description = "신고된 타겟 데이터의 대해서 삭제 API")
+    CommonResponse<Boolean> deleteReport(Long id, AdminReportReqDto.AdminReportDelete body);
+
+
+}

--- a/src/main/java/com/hambug/Hambug/domain/admin/controller/AdminAuthController.java
+++ b/src/main/java/com/hambug/Hambug/domain/admin/controller/AdminAuthController.java
@@ -17,11 +17,11 @@ import org.springframework.web.bind.annotation.RestController;
 import static com.hambug.Hambug.domain.admin.dto.AdminUserReqDTO.AdminLogin;
 import static com.hambug.Hambug.domain.admin.dto.AdminUserReqDTO.RegisterAdminUser;
 
-@RequestMapping("/admin/api/v1")
+@RequestMapping("/admin/api/v1/auth")
 @RestController
 @RequiredArgsConstructor
 @Slf4j
-public class AdminController implements AdminApi {
+public class AdminAuthController implements AdminApi {
 
     private final AdminUserService userService;
 

--- a/src/main/java/com/hambug/Hambug/domain/admin/controller/AdminAuthController.java
+++ b/src/main/java/com/hambug/Hambug/domain/admin/controller/AdminAuthController.java
@@ -26,13 +26,16 @@ public class AdminAuthController implements AdminApi {
     private final AdminUserService userService;
 
     @PostMapping("/register")
-    public AdminUserResponseDto.AdminUserResponse createAdminUser(@RequestBody RegisterAdminUser body) {
-        return userService.createAdminUser(body);
+    public CommonResponse<AdminUserResponseDto.AdminUserResponse> createAdminUser(@RequestBody RegisterAdminUser body) {
+        AdminUserResponseDto.AdminUserResponse adminUser = userService.createAdminUser(body);
+        return CommonResponse.ok(adminUser);
     }
 
     @PostMapping("/register/manager")
-    public AdminUserResponseDto.AdminUserResponse createManagerUser(@RequestBody RegisterAdminUser body, @AuthenticationPrincipal PrincipalDetails principalDetails) {
-        return userService.createManagerUser(body);
+    public CommonResponse<AdminUserResponseDto.AdminUserResponse> createManagerUser(@RequestBody RegisterAdminUser body,
+                                                                                    @AuthenticationPrincipal PrincipalDetails principalDetails) {
+        AdminUserResponseDto.AdminUserResponse managerUser = userService.createManagerUser(body);
+        return CommonResponse.ok(managerUser);
     }
 
     @PostMapping("/login")

--- a/src/main/java/com/hambug/Hambug/domain/admin/controller/AdminController.java
+++ b/src/main/java/com/hambug/Hambug/domain/admin/controller/AdminController.java
@@ -1,9 +1,13 @@
 package com.hambug.Hambug.domain.admin.controller;
 
+import com.hambug.Hambug.domain.admin.api.AdminApi;
+import com.hambug.Hambug.domain.admin.dto.AdminUserReqDTO;
+import com.hambug.Hambug.domain.admin.dto.AdminUserResponseDto;
 import com.hambug.Hambug.domain.admin.service.AdminUserService;
-import com.hambug.Hambug.domain.auth.dto.JwtTokenDto;
 import com.hambug.Hambug.domain.oauth.entity.PrincipalDetails;
+import com.hambug.Hambug.global.response.CommonResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -16,23 +20,41 @@ import static com.hambug.Hambug.domain.admin.dto.AdminUserReqDTO.RegisterAdminUs
 @RequestMapping("/admin/api/v1")
 @RestController
 @RequiredArgsConstructor
-public class AdminController {
+@Slf4j
+public class AdminController implements AdminApi {
 
     private final AdminUserService userService;
 
     @PostMapping("/register")
-    public String createAdminUser(@RequestBody RegisterAdminUser body) {
+    public AdminUserResponseDto.AdminUserResponse createAdminUser(@RequestBody RegisterAdminUser body) {
         return userService.createAdminUser(body);
     }
 
     @PostMapping("/register/manager")
-    public String createManagerUser(@RequestBody RegisterAdminUser body, @AuthenticationPrincipal PrincipalDetails principalDetails) {
+    public AdminUserResponseDto.AdminUserResponse createManagerUser(@RequestBody RegisterAdminUser body, @AuthenticationPrincipal PrincipalDetails principalDetails) {
         return userService.createManagerUser(body);
     }
 
     @PostMapping("/login")
-    public JwtTokenDto login(@RequestBody AdminLogin body) {
+    public AdminUserResponseDto.AdminLoginResponse login(@RequestBody AdminLogin body) {
         return userService.login(body);
+    }
+
+    @PostMapping("/send-email")
+    public CommonResponse<AdminUserResponseDto.AdminValidSendEmailResponse> sendEmail(@RequestBody AdminUserReqDTO.AdminValidSendEmail boy) {
+        return CommonResponse.ok(userService.sendEmail(boy));
+    }
+
+    @PostMapping("/verification-email")
+    public CommonResponse<Boolean> verificationEmail(@RequestBody AdminUserReqDTO.VerificationEmail body) {
+        userService.verificationEmail(body);
+        return CommonResponse.ok(true);
+    }
+
+    @PostMapping("/password/reset")
+    public CommonResponse<Boolean> resetPassword(@RequestBody AdminUserReqDTO.ResetPassword body) {
+        boolean resetPassword = userService.resetPassword(body);
+        return CommonResponse.ok(resetPassword);
     }
 
 }

--- a/src/main/java/com/hambug/Hambug/domain/admin/controller/AdminReportController.java
+++ b/src/main/java/com/hambug/Hambug/domain/admin/controller/AdminReportController.java
@@ -1,5 +1,6 @@
 package com.hambug.Hambug.domain.admin.controller;
 
+import com.hambug.Hambug.domain.admin.api.AdminReportApi;
 import com.hambug.Hambug.domain.admin.dto.AdminReportReqDto;
 import com.hambug.Hambug.domain.admin.dto.AdminReportResponseDto;
 import com.hambug.Hambug.domain.admin.service.AdminReportService;
@@ -11,7 +12,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/admin/api/v1/reports")
 @RequiredArgsConstructor
-public class AdminReportController {
+public class AdminReportController implements AdminReportApi {
 
     private final AdminReportService adminReportService;
 

--- a/src/main/java/com/hambug/Hambug/domain/admin/controller/AdminReportController.java
+++ b/src/main/java/com/hambug/Hambug/domain/admin/controller/AdminReportController.java
@@ -1,0 +1,33 @@
+package com.hambug.Hambug.domain.admin.controller;
+
+import com.hambug.Hambug.domain.admin.dto.AdminReportReqDto;
+import com.hambug.Hambug.domain.admin.dto.AdminReportResponseDto;
+import com.hambug.Hambug.domain.admin.service.AdminReportService;
+import com.hambug.Hambug.global.response.CommonResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/admin/api/v1/reports")
+@RequiredArgsConstructor
+public class AdminReportController {
+
+    private final AdminReportService adminReportService;
+
+    @GetMapping()
+    public CommonResponse<AdminReportResponseDto.Page> getReports(@ModelAttribute AdminReportReqDto.AdminReportPageRequest request) {
+        return CommonResponse.ok(adminReportService.adminReportPage(request));
+    }
+
+    @GetMapping("/targets/{id}")
+    public CommonResponse<AdminReportResponseDto.DetailPage> getReport(@PathVariable("id") Long id, @ModelAttribute AdminReportReqDto.AdminReportPageRequest request) {
+        return CommonResponse.ok(adminReportService.adminReport(id, request));
+    }
+
+    @DeleteMapping("/targets/{id}")
+    public CommonResponse<Boolean> deleteReport(@PathVariable("id") Long id, @RequestBody @Valid AdminReportReqDto.AdminReportDelete body) {
+        return CommonResponse.ok(adminReportService.deleteReport(id, body));
+    }
+
+}

--- a/src/main/java/com/hambug/Hambug/domain/admin/dto/AdminReportReqDto.java
+++ b/src/main/java/com/hambug/Hambug/domain/admin/dto/AdminReportReqDto.java
@@ -1,0 +1,67 @@
+package com.hambug.Hambug.domain.admin.dto;
+
+import com.hambug.Hambug.global.util.PageParams;
+import jakarta.validation.constraints.NotNull;
+
+public class AdminReportReqDto {
+
+    public record AdminReportPageRequest(
+            Integer type,
+            PageParams params,
+            Long lastId,
+            Integer pageLimit,
+            Integer pageOffset,
+            String sortOrder,
+            Integer limit,
+            Integer offset,
+            String order
+    ) {
+        public PageParams effectiveParams() {
+            Integer effectiveLimit = (pageLimit != null) ? pageLimit : limit;
+            Integer effectiveOffset = (pageOffset != null) ? pageOffset : offset;
+            String effectiveOrder = (sortOrder != null) ? sortOrder : order;
+
+            if (params == null) {
+                return new PageParams(effectiveLimit, effectiveOffset, lastId, effectiveOrder);
+            }
+            if (lastId != null) params.setLastId(lastId);
+            if (effectiveLimit != null) params.setPageLimit(effectiveLimit);
+            if (effectiveOffset != null) params.setPageOffset(effectiveOffset);
+            if (effectiveOrder != null) params.setSortOrder(effectiveOrder);
+            return params;
+        }
+    }
+
+    public record AdminReportRequest(
+            Long id,
+            PageParams params,
+            Long lastId,
+            Integer pageLimit,
+            Integer pageOffset,
+            String sortOrder,
+            Integer limit,
+            Integer offset,
+            String order
+    ) {
+        public PageParams effectiveParams() {
+            Integer effectiveLimit = (pageLimit != null) ? pageLimit : limit;
+            Integer effectiveOffset = (pageOffset != null) ? pageOffset : offset;
+            String effectiveOrder = (sortOrder != null) ? sortOrder : order;
+
+            if (params == null) {
+                return new PageParams(effectiveLimit, effectiveOffset, lastId, effectiveOrder);
+            }
+            if (lastId != null) params.setLastId(lastId);
+            if (effectiveLimit != null) params.setPageLimit(effectiveLimit);
+            if (effectiveOffset != null) params.setPageOffset(effectiveOffset);
+            if (effectiveOrder != null) params.setSortOrder(effectiveOrder);
+            return params;
+        }
+    }
+
+    public record AdminReportDelete(
+            @NotNull(message = "타입을 입력해주세요")
+            Integer type
+    ) {
+    }
+}

--- a/src/main/java/com/hambug/Hambug/domain/admin/dto/AdminReportResponseDto.java
+++ b/src/main/java/com/hambug/Hambug/domain/admin/dto/AdminReportResponseDto.java
@@ -1,0 +1,48 @@
+package com.hambug.Hambug.domain.admin.dto;
+
+import com.hambug.Hambug.domain.report.entity.TargetType;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class AdminReportResponseDto {
+
+    public record GroupedReport(Long targetId, TargetType targetType, Long latestReportId, Long reportCount) {
+    }
+
+    public record Page(Boolean nextPage, Long netCursorId, List<GroupedReport> content) {
+    }
+
+    public record DetailPage(Boolean nextPage, Long netCursorId, List<ReportDetail> content) {
+    }
+
+    public record DetailReport(Long id, String title, String content, String authorNickname, Long authorId) {
+    }
+
+    public record ReportGroupSummary(
+            Long targetId,
+            TargetType targetType,
+            Long latestReportId,
+            Long reportCount
+    ) {
+    }
+
+    public record ReportDetail(
+            Long id,
+            Long authorId,
+            String nickname,
+            String reason,
+            LocalDateTime createdAt
+    ) {
+    }
+
+    public record ReportGroupSummaryWithTarget(
+            Long targetId,
+            TargetType targetType,
+            Long latestReportId,
+            Long reportCount,
+            String boardTitle,   // BOARD일 때
+            String commentContent // COMMENT일 때
+    ) {
+    }
+}

--- a/src/main/java/com/hambug/Hambug/domain/admin/dto/AdminUserReqDTO.java
+++ b/src/main/java/com/hambug/Hambug/domain/admin/dto/AdminUserReqDTO.java
@@ -1,6 +1,7 @@
 package com.hambug.Hambug.domain.admin.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 public class AdminUserReqDTO {
 
@@ -20,4 +21,27 @@ public class AdminUserReqDTO {
             String password) {
     }
 
+    public record ResetPassword(
+            @NotBlank(message = "이메일은 필수 입니다.")
+            String email,
+            @NotBlank(message = "기존 비밀번호는 필수 입니다.")
+            String oldPassword,
+            @NotBlank(message = "새 비밀번호는 필수 입니다.")
+            String newPassword) {
+    }
+
+    public record AdminValidSendEmail(
+            @NotBlank(message = "이메일은 필수 입니다.")
+            String email
+    ) {
+    }
+
+    public record VerificationEmail(
+            @NotNull(message = "검증아이디를 입력해주세요")
+            Long emailVerificationId,
+
+            @NotBlank(message = "인증 코드를 입력해주세요")
+            String verificationCode
+    ) {
+    }
 }

--- a/src/main/java/com/hambug/Hambug/domain/admin/dto/AdminUserResponseDto.java
+++ b/src/main/java/com/hambug/Hambug/domain/admin/dto/AdminUserResponseDto.java
@@ -1,0 +1,45 @@
+package com.hambug.Hambug.domain.admin.dto;
+
+import com.hambug.Hambug.domain.admin.entity.AdminUser;
+import com.hambug.Hambug.domain.auth.dto.JwtTokenDto;
+
+import java.time.LocalDateTime;
+
+public class AdminUserResponseDto {
+    public record AdminUserResponse(Long id, String email, String name, String role, boolean isTempPassword, String tempPassword) {
+
+        public AdminUserResponse(AdminUser adminUser, String tempPassword) {
+            this(
+                    adminUser.getId(),
+                    adminUser.getEmail(),
+                    adminUser.getName(),
+                    adminUser.getRole().name(),
+                    false,
+                    tempPassword
+            );
+        }
+    }
+
+    public record AdminLoginResponse(Long id, String email, String name, String role, boolean isTempPassword, String accessToken,
+                                     String refreshToken) {
+        public static AdminLoginResponse of(AdminUser adminUser, JwtTokenDto tokens) {
+            return new AdminLoginResponse(
+                    adminUser.getId(),
+                    adminUser.getEmail(),
+                    adminUser.getName(),
+                    adminUser.getRole().name(),
+                    adminUser.getIsTempPassword(),
+                    tokens != null ? tokens.getAccessToken() : null,
+                    tokens != null ? tokens.getRefreshToken() : null
+            );
+        }
+    }
+
+    public record AdminValidSendEmailResponse(Long verificationId, LocalDateTime expiredAt) {
+        public AdminValidSendEmailResponse(Long verificationId, LocalDateTime expiredAt) {
+            this.verificationId = verificationId;
+            this.expiredAt = expiredAt;
+        }
+
+    }
+}

--- a/src/main/java/com/hambug/Hambug/domain/admin/entity/AdminUser.java
+++ b/src/main/java/com/hambug/Hambug/domain/admin/entity/AdminUser.java
@@ -44,7 +44,7 @@ public class AdminUser extends Timestamped {
                 .email(email)
                 .password(hashed)
                 .salt(salt)
-                .isTempPassword(true)
+                .isTempPassword(false)
                 .role(Role.ROLE_SUPER_ADMIN)
                 .build();
     }
@@ -55,7 +55,7 @@ public class AdminUser extends Timestamped {
                 .email(email)
                 .password(hashed)
                 .salt(salt)
-                .isTempPassword(true)
+                .isTempPassword(false)
                 .role(Role.ROLE_ADMIN)
                 .build();
     }

--- a/src/main/java/com/hambug/Hambug/domain/admin/entity/EmailVerification.java
+++ b/src/main/java/com/hambug/Hambug/domain/admin/entity/EmailVerification.java
@@ -50,4 +50,19 @@ public class EmailVerification {
         this.code = String.format("%06d", (int) (Math.random() * 1000000));
         return this.code;
     }
+
+    public boolean isVerified(String code) {
+        if (this.expiredAt.isBefore(LocalDateTime.now())) {
+            return false;
+        }
+        return !this.isVerified && this.code.equals(code);
+    }
+
+    public boolean isVerified() {
+        return this.isVerified;
+    }
+
+    public void markVerified() {
+        this.isVerified = true;
+    }
 }

--- a/src/main/java/com/hambug/Hambug/domain/admin/service/AdminReportService.java
+++ b/src/main/java/com/hambug/Hambug/domain/admin/service/AdminReportService.java
@@ -1,0 +1,69 @@
+package com.hambug.Hambug.domain.admin.service;
+
+import com.hambug.Hambug.domain.admin.dto.AdminReportReqDto;
+import com.hambug.Hambug.domain.admin.dto.AdminReportResponseDto;
+import com.hambug.Hambug.domain.board.service.BoardService;
+import com.hambug.Hambug.domain.comment.service.CommentService;
+import com.hambug.Hambug.domain.report.entity.TargetType;
+import com.hambug.Hambug.domain.report.service.ReportService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AdminReportService {
+
+    private final ReportService reportService;
+    private final BoardService boardService;
+    private final CommentService commentService;
+
+    public AdminReportResponseDto.Page adminReportPage(AdminReportReqDto.AdminReportPageRequest request) {
+        Slice<AdminReportResponseDto.ReportGroupSummary> slice = reportService.groupedReportPage(toTargetType(request.type()), request.effectiveParams());
+        List<AdminReportResponseDto.GroupedReport> data = slice.getContent().stream()
+                .map(s -> new AdminReportResponseDto.GroupedReport(s.targetId(), s.targetType(), s.latestReportId(), s.reportCount()))
+                .toList();
+        return new AdminReportResponseDto.Page(slice.hasNext(), calculateNextId(slice, data), data);
+    }
+
+    public AdminReportResponseDto.DetailPage adminReport(Long id, AdminReportReqDto.AdminReportPageRequest request) {
+        Slice<AdminReportResponseDto.ReportDetail> slice = reportService.detailReport(id, request.effectiveParams());
+        List<AdminReportResponseDto.ReportDetail> content = slice.getContent();
+        return new AdminReportResponseDto.DetailPage(slice.hasNext(), calculateNextId2(slice, content), content);
+    }
+
+
+    private Long calculateNextId(Slice<AdminReportResponseDto.ReportGroupSummary> slice, List<AdminReportResponseDto.GroupedReport> data) {
+        Long nextCursorId = null;
+        if (slice.hasNext() && !data.isEmpty()) {
+            nextCursorId = data.get(data.size() - 1).latestReportId(); // or targetId(), depending on your paging key
+        }
+        return nextCursorId;
+    }
+
+    private Long calculateNextId2(Slice<AdminReportResponseDto.ReportDetail> slice, List<AdminReportResponseDto.ReportDetail> data) {
+        Long nextCursorId = null;
+        if (slice.hasNext() && !data.isEmpty()) {
+            nextCursorId = data.get(data.size() - 1).id(); // or targetId(), depending on your paging key
+        }
+        return nextCursorId;
+    }
+
+    public Boolean deleteReport(Long id, AdminReportReqDto.AdminReportDelete body) {
+        TargetType targetType = toTargetType(body.type());
+        if (targetType.equals(TargetType.BOARD)) {
+            return boardService.deleteBoardForAdmin(id);
+        }
+        return commentService.deleteCommentForAdmin(id);
+    }
+
+    private TargetType toTargetType(Integer type) {
+        if (type == null) return null; // null means fetch all types
+        return switch (type) {
+            case 1 -> TargetType.BOARD;
+            default -> TargetType.COMMENT;
+        };
+    }
+}

--- a/src/main/java/com/hambug/Hambug/domain/admin/service/AdminUserService.java
+++ b/src/main/java/com/hambug/Hambug/domain/admin/service/AdminUserService.java
@@ -1,8 +1,9 @@
 package com.hambug.Hambug.domain.admin.service;
 
 import com.hambug.Hambug.domain.admin.dto.AdminUserDto;
-import com.hambug.Hambug.domain.admin.dto.AdminUserReqDTO;
+import com.hambug.Hambug.domain.admin.dto.AdminUserResponseDto;
 import com.hambug.Hambug.domain.admin.entity.AdminUser;
+import com.hambug.Hambug.domain.admin.entity.EmailVerification;
 import com.hambug.Hambug.domain.admin.repository.AdminUserRepository;
 import com.hambug.Hambug.domain.admin.util.PasswordUtil;
 import com.hambug.Hambug.domain.auth.dto.JwtTokenDto;
@@ -14,6 +15,10 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+import static com.hambug.Hambug.domain.admin.dto.AdminUserReqDTO.*;
 
 @Slf4j
 @Service
@@ -31,7 +36,7 @@ public class AdminUserService {
         return AdminUserDto.of(adminUser);
     }
 
-    public String createAdminUser(AdminUserReqDTO.RegisterAdminUser dto) {
+    public AdminUserResponseDto.AdminUserResponse createAdminUser(RegisterAdminUser dto) {
         userRepository.findByEmail(dto.email())
                 .ifPresent(user -> {
                     throw new IllegalArgumentException("이미 존재하는 이메일입니다: " + dto.email());
@@ -39,12 +44,12 @@ public class AdminUserService {
         String tempPassword = PasswordUtil.generateTempPassword(16);
         String salt = PasswordUtil.generateSalt(16);
         String hashed = PasswordUtil.hashWithPbkdf2(tempPassword, salt);
-        userRepository.save(AdminUser.admin_of(dto.name(), dto.email(), hashed, salt));
+        AdminUser adminUser = userRepository.save(AdminUser.admin_of(dto.name(), dto.email(), hashed, salt));
 
-        return tempPassword;
+        return new AdminUserResponseDto.AdminUserResponse(adminUser, tempPassword);
     }
 
-    public String createManagerUser(AdminUserReqDTO.RegisterAdminUser dto) {
+    public AdminUserResponseDto.AdminUserResponse createManagerUser(RegisterAdminUser dto) {
         userRepository.findByEmail(dto.email())
                 .ifPresent(user -> {
                     throw new IllegalArgumentException("이미 존재하는 이메일입니다: " + dto.email());
@@ -52,22 +57,79 @@ public class AdminUserService {
         String tempPassword = PasswordUtil.generateTempPassword(16);
         String salt = PasswordUtil.generateSalt(16);
         String hashed = PasswordUtil.hashWithPbkdf2(tempPassword, salt);
-        userRepository.save(AdminUser.manager_of(dto.name(), dto.email(), hashed, salt));
+        AdminUser adminUser = userRepository.save(AdminUser.manager_of(dto.name(), dto.email(), hashed, salt));
 
-        return tempPassword;
+        return new AdminUserResponseDto.AdminUserResponse(adminUser, tempPassword);
     }
 
-    public JwtTokenDto login(AdminUserReqDTO.AdminLogin body) {
+    public AdminUserResponseDto.AdminLoginResponse login(AdminLogin body) {
         AdminUser user = userRepository.findByEmail(body.email())
                 .orElseThrow(() -> new EntityNotFoundException("이메일 또는 비밀번호가 올바르지 않습니다."));
         if (user.getRole().equals(Role.ROLE_ADMIN) && !user.isEmailVerification()) {
-            emailVerificationService.create(user);
+//            emailVerificationService.create(user);
             throw new RuntimeException("이메일 인증이 안되어 있습니다.");
         }
         boolean pwOk = PasswordUtil.matchesPbkdf2(body.password(), user.getSalt(), user.getPassword());
         if (!pwOk) {
             throw new EntityNotFoundException("이메일 또는 비밀번호가 올바르지 않습니다.");
         }
-        return jwtService.generateTokens(new AdminJwtPrincipalAdapter(user));
+        JwtTokenDto tokens = jwtService.generateTokens(new AdminJwtPrincipalAdapter(user));
+        return AdminUserResponseDto.AdminLoginResponse.of(user, tokens);
+    }
+
+    public boolean resetPassword(ResetPassword body) {
+        AdminUser user = userRepository.findByEmail(body.email())
+                .orElseThrow(() -> new EntityNotFoundException("관리자 계정을 찾을 수 없습니다."));
+
+        if (Boolean.TRUE.equals(user.getIsTempPassword())) {
+            throw new IllegalStateException("임시 비밀번호 상태에서는 비밀번호 재설정을 사용할 수 없습니다.");
+        }
+        if (user.getRole().equals(Role.ROLE_ADMIN) && !user.isEmailVerification()) {
+            throw new IllegalArgumentException("이메일 인증하기 전에는 비밀번호 재설정을 사용할 수 없습니다.");
+        }
+
+        PasswordUtil.matchesPbkdf2(body.oldPassword(), user.getSalt(), user.getPassword());
+
+        String newSalt = PasswordUtil.generateSalt(16);
+        String newHash = PasswordUtil.hashWithPbkdf2(body.newPassword(), newSalt);
+        user.setSalt(newSalt);
+        user.setPassword(newHash);
+        user.setIsTempPassword(true);
+        return true;
+    }
+
+    public AdminUserResponseDto.AdminValidSendEmailResponse sendEmail(AdminValidSendEmail body) {
+        Optional<AdminUser> byEmail = userRepository.findByEmail(body.email());
+        if (byEmail.isEmpty()) {
+            throw new EntityNotFoundException("해당 어드민 계정을 찾을수 없습니다.");
+        }
+        AdminUser adminUser = byEmail.get();
+        if (!adminUser.getRole().equals(Role.ROLE_ADMIN)) {
+            throw new EntityNotFoundException("해당 어드민 계정을 찾을수 없습니다.");
+        }
+        EmailVerification emailVerification = emailVerificationService.create(adminUser);
+        return new AdminUserResponseDto.AdminValidSendEmailResponse(emailVerification.getId(), emailVerification.getExpiredAt());
+    }
+
+    public void verificationEmail(VerificationEmail body) {
+        EmailVerification emailVerification = emailVerificationService.findById(body.emailVerificationId());
+
+        // 이미 인증된 경우는 아이덴포턴트하게 통과
+        if (emailVerification.isVerified()) {
+            return;
+        }
+
+        // 만료 여부 검사
+        if (emailVerification.isExpired()) {
+            throw new IllegalArgumentException("인증코드가 만료되었습니다.");
+        }
+
+        // 코드 일치 검사
+        if (!emailVerification.isVerified(body.verificationCode())) {
+            throw new IllegalArgumentException("해당 인증코드는 잘못된 코드입니다.");
+        }
+
+        // 인증 완료 상태 반영
+        emailVerification.markVerified();
     }
 }

--- a/src/main/java/com/hambug/Hambug/domain/admin/service/EmailVerificationService.java
+++ b/src/main/java/com/hambug/Hambug/domain/admin/service/EmailVerificationService.java
@@ -5,6 +5,7 @@ import com.hambug.Hambug.domain.admin.entity.EmailVerification;
 import com.hambug.Hambug.domain.admin.repository.EmailVerificationRepository;
 import com.hambug.Hambug.global.email.EmailMessage;
 import com.hambug.Hambug.global.email.EmailService;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -19,7 +20,12 @@ public class EmailVerificationService {
     private final EmailVerificationRepository emailVerificationRepository;
     private final EmailService emailService;
 
-    public void create(AdminUser adminUser) {
+    public EmailVerification findById(Long id) {
+        return emailVerificationRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("이메일 인증코드를 찾을수 없습니다."));
+    }
+
+    public EmailVerification create(AdminUser adminUser) {
         EmailVerification ev = adminUser.getEmailVerification();
         String code;
         if (ev == null) {
@@ -38,15 +44,16 @@ public class EmailVerificationService {
                     .to(adminUser.getEmail())
                     .subject("[Hambug] 관리자 이메일 인증 코드")
                     .body("안녕하세요, " + adminUser.getName() + "님!<br><br>" +
-                          "아래 이메일 인증 코드를 입력해 주세요:<br>" +
-                          "<h2 style='letter-spacing:3px;'>" + code + "</h2>" +
-                          "코드는 5분간 유효합니다.")
+                            "아래 이메일 인증 코드를 입력해 주세요:<br>" +
+                            "<h2 style='letter-spacing:3px;'>" + code + "</h2>" +
+                            "코드는 5분간 유효합니다.")
                     .html(true)
                     .build();
             emailService.sendEmail(message);
         } catch (Exception e) {
             log.warn("이메일 전송 실패: {}", e.getMessage());
         }
+        return ev;
     }
 
 }

--- a/src/main/java/com/hambug/Hambug/domain/auth/api/AuthApi.java
+++ b/src/main/java/com/hambug/Hambug/domain/auth/api/AuthApi.java
@@ -1,6 +1,6 @@
 package com.hambug.Hambug.domain.auth.api;
 
-import com.hambug.Hambug.domain.auth.dto.JwtTokenDto;
+import com.hambug.Hambug.domain.auth.dto.AuthResponseDto;
 import com.hambug.Hambug.domain.auth.dto.Oauth2RequestDTO;
 import com.hambug.Hambug.domain.oauth.entity.PrincipalDetails;
 import com.hambug.Hambug.domain.user.dto.UserDto;
@@ -35,5 +35,5 @@ public interface AuthApi {
             , @AuthenticationPrincipal PrincipalDetails principalDetails);
 
     @Operation(summary = "소셜 로그인", description = "provider(kakao|apple)와 인가코드로 로그인")
-    CommonResponse<JwtTokenDto> login(String provider, Oauth2RequestDTO.LoginAuthCode payload);
+    CommonResponse<AuthResponseDto.LoginResponse> login(String provider, Oauth2RequestDTO.LoginAuthCode payload);
 }

--- a/src/main/java/com/hambug/Hambug/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/hambug/Hambug/domain/auth/controller/AuthController.java
@@ -1,7 +1,7 @@
 package com.hambug.Hambug.domain.auth.controller;
 
 import com.hambug.Hambug.domain.auth.api.AuthApi;
-import com.hambug.Hambug.domain.auth.dto.JwtTokenDto;
+import com.hambug.Hambug.domain.auth.dto.AuthResponseDto;
 import com.hambug.Hambug.domain.auth.dto.Oauth2RequestDTO;
 import com.hambug.Hambug.domain.auth.service.JwtService;
 import com.hambug.Hambug.domain.auth.service.oauth2.Oauth2ServiceFactory;
@@ -63,8 +63,8 @@ public class AuthController implements AuthApi {
     }
 
     @PostMapping("/login/{provider}")
-    public CommonResponse<JwtTokenDto> login(@PathVariable String provider,
-                                             @RequestBody @Valid Oauth2RequestDTO.LoginAuthCode payload) {
+    public CommonResponse<AuthResponseDto.LoginResponse> login(@PathVariable String provider,
+                                                               @RequestBody @Valid Oauth2RequestDTO.LoginAuthCode payload) {
         UserDto userDto = oauth2ServiceFactory.getService(provider).login(payload.authorizationCode());
 
         PrincipalDetails principal = new PrincipalDetails(userDto);
@@ -80,8 +80,7 @@ public class AuthController implements AuthApi {
             attrs.getRequest().getSession(true)
                     .setAttribute(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY, context);
         }
-
-        return CommonResponse.ok(userDto.toJwtTokenDto());
+        return CommonResponse.ok(new AuthResponseDto.LoginResponse(userDto, userDto.toJwtTokenDto()));
     }
 
     private Long getUserId(PrincipalDetails principalDetails) {

--- a/src/main/java/com/hambug/Hambug/domain/auth/dto/AuthResponseDto.java
+++ b/src/main/java/com/hambug/Hambug/domain/auth/dto/AuthResponseDto.java
@@ -1,0 +1,9 @@
+package com.hambug.Hambug.domain.auth.dto;
+
+import com.hambug.Hambug.domain.user.dto.UserDto;
+
+public class AuthResponseDto {
+
+    public record LoginResponse(UserDto user, JwtTokenDto token) {
+    }
+}

--- a/src/main/java/com/hambug/Hambug/domain/auth/dto/KakaoUserResponse.java
+++ b/src/main/java/com/hambug/Hambug/domain/auth/dto/KakaoUserResponse.java
@@ -29,16 +29,6 @@ public class KakaoUserResponse implements Oauth2UserInfo {
     }
 
     @Override
-    public String getEmail() {
-        return kakaoAccount.getEmail();
-    }
-
-    @Override
-    public String getName() {
-        return kakaoAccount.getProfile().getNickname();
-    }
-
-    @Override
     public LoginType getLoginType() {
         return LoginType.KAKAO;
     }

--- a/src/main/java/com/hambug/Hambug/domain/auth/service/oauth2/KakaoOauthService.java
+++ b/src/main/java/com/hambug/Hambug/domain/auth/service/oauth2/KakaoOauthService.java
@@ -41,8 +41,6 @@ public class KakaoOauthService implements Oauth2Service {
         // 1) 액세스 토큰 요청
         TokenResponse token = getTokenResponse(code);
 
-        log.info("토킁느 : {}", token);
-
         KakaoUserResponse me = webClient.get()
                 .uri("https://kapi.kakao.com/v2/user/me")
                 .headers(h -> h.setBearerAuth(Objects.requireNonNull(token).getAccessToken()))
@@ -50,7 +48,7 @@ public class KakaoOauthService implements Oauth2Service {
                 .retrieve()
                 .bodyToMono(KakaoUserResponse.class)
                 .block();
-        
+
         Objects.requireNonNull(me).addToken(token);
         return userService.signUpOrLogin(me);
     }
@@ -106,7 +104,6 @@ public class KakaoOauthService implements Oauth2Service {
     }
 
     private BodyInserters.FormInserter<String> getStringFormInserter(String code) {
-        log.debug("카카오톡 redirect_uri: {}", kakaoRedirectUri);
         return BodyInserters
                 .fromFormData("grant_type", "authorization_code")
                 .with("client_id", kakaoClientId)

--- a/src/main/java/com/hambug/Hambug/domain/board/service/BoardService.java
+++ b/src/main/java/com/hambug/Hambug/domain/board/service/BoardService.java
@@ -61,14 +61,14 @@ public class BoardService {
                 .imageUrls(request.imageUrls())
                 .user(user)
                 .build();
-        
+
         boardRepository.save(board);
         return new BoardResponseDTO.BoardResponse(board);
     }
 
     @Transactional
-    public BoardResponseDTO.BoardResponse createBoardWithImages(BoardRequestDTO.BoardCreateRequest request, 
-                                                               List<MultipartFile> images, Long userId) {
+    public BoardResponseDTO.BoardResponse createBoardWithImages(BoardRequestDTO.BoardCreateRequest request,
+                                                                List<MultipartFile> images, Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."));
 
@@ -94,7 +94,7 @@ public class BoardService {
                 .imageUrls(imageUrls)
                 .user(user)
                 .build();
-        
+
         boardRepository.save(board);
         return new BoardResponseDTO.BoardResponse(board);
     }
@@ -113,8 +113,8 @@ public class BoardService {
     }
 
     @Transactional
-    public BoardResponseDTO.BoardResponse updateBoardWithImages(Long id, BoardRequestDTO.BoardUpdateRequest request, 
-                                                               List<MultipartFile> images, Long userId) {
+    public BoardResponseDTO.BoardResponse updateBoardWithImages(Long id, BoardRequestDTO.BoardUpdateRequest request,
+                                                                List<MultipartFile> images, Long userId) {
         Board board = boardRepository.findById(id)
                 .orElseThrow(() -> new BoardNotFoundException(ErrorCode.BOARD_NOT_FOUND));
 
@@ -151,5 +151,13 @@ public class BoardService {
         }
 
         boardRepository.delete(board);
+    }
+
+    @Transactional
+    public boolean deleteBoardForAdmin(Long id) {
+        Board board = boardRepository.findById(id)
+                .orElseThrow(() -> new BoardNotFoundException(ErrorCode.BOARD_NOT_FOUND));
+        boardRepository.delete(board);
+        return true;
     }
 }

--- a/src/main/java/com/hambug/Hambug/domain/comment/service/CommentService.java
+++ b/src/main/java/com/hambug/Hambug/domain/comment/service/CommentService.java
@@ -6,8 +6,8 @@ import com.hambug.Hambug.domain.comment.dto.CommentRequestDTO;
 import com.hambug.Hambug.domain.comment.dto.CommentResponseDTO;
 import com.hambug.Hambug.domain.comment.entity.Comment;
 import com.hambug.Hambug.domain.comment.repository.CommentRepository;
-import com.hambug.Hambug.global.exception.custom.NotFoundException;
 import com.hambug.Hambug.global.exception.ErrorCode;
+import com.hambug.Hambug.global.exception.custom.NotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -76,5 +76,11 @@ public class CommentService {
         if (!comment.getBoard().getId().equals(boardId)) {
             throw new NotFoundException(ErrorCode.COMMENT_BOARD_MISMATCH);
         }
+    }
+
+    public boolean deleteCommentForAdmin(Long id) {
+        Comment comment = findComment(id);
+        commentRepository.delete(comment);
+        return true;
     }
 }

--- a/src/main/java/com/hambug/Hambug/domain/oauth/entity/PrincipalDetails.java
+++ b/src/main/java/com/hambug/Hambug/domain/oauth/entity/PrincipalDetails.java
@@ -65,7 +65,7 @@ public class PrincipalDetails implements OAuth2User, OidcUser {
     @Override
     public String getName() {
         if (user != null) {
-            return user.getUserId() == null ? user.getName() : String.valueOf(user.getUserId());
+            return user.getUserId() == null ? user.getNickname() : String.valueOf(user.getUserId());
         }
         if (admin != null) {
             return admin.getEmail() != null ? admin.getEmail() : admin.getName();

--- a/src/main/java/com/hambug/Hambug/domain/oauth/service/Oauth2UserInfo.java
+++ b/src/main/java/com/hambug/Hambug/domain/oauth/service/Oauth2UserInfo.java
@@ -6,10 +6,6 @@ public interface Oauth2UserInfo {
 
     String getId();
 
-    String getEmail();
-
-    String getName();
-
     LoginType getLoginType();
 
     String getRefreshToken();

--- a/src/main/java/com/hambug/Hambug/domain/oauth/service/impl/AppleUserInfo.java
+++ b/src/main/java/com/hambug/Hambug/domain/oauth/service/impl/AppleUserInfo.java
@@ -20,32 +20,6 @@ public class AppleUserInfo implements Oauth2UserInfo {
     }
 
     @Override
-    public String getEmail() {
-        Object email = attributes.get("email");
-        return email == null ? null : String.valueOf(email);
-    }
-
-    @Override
-    public String getName() {
-        Object name = attributes.get("name");
-        if (name != null) return String.valueOf(name);
-        Object givenName = attributes.get("given_name");
-        Object familyName = attributes.get("family_name");
-        if (givenName != null || familyName != null) {
-            String g = givenName == null ? "" : String.valueOf(givenName);
-            String f = familyName == null ? "" : String.valueOf(familyName);
-            String full = (g + " " + f).trim();
-            if (!full.isEmpty()) return full;
-        }
-        String email = getEmail();
-        if (email != null) {
-            int at = email.indexOf('@');
-            return at > 0 ? email.substring(0, at) : email;
-        }
-        return "AppleUser";
-    }
-
-    @Override
     public LoginType getLoginType() {
         return LoginType.APPLE;
     }

--- a/src/main/java/com/hambug/Hambug/domain/oauth/service/impl/KakaoUserInfo.java
+++ b/src/main/java/com/hambug/Hambug/domain/oauth/service/impl/KakaoUserInfo.java
@@ -24,16 +24,6 @@ public class KakaoUserInfo implements Oauth2UserInfo {
     }
 
     @Override
-    public String getEmail() {
-        return kakao_account.get("email");
-    }
-
-    @Override
-    public String getName() {
-        return (String) kakaoProperties.get("nickname");
-    }
-
-    @Override
     public LoginType getLoginType() {
         return LoginType.KAKAO;
     }

--- a/src/main/java/com/hambug/Hambug/domain/report/repository/CustomReportRepository.java
+++ b/src/main/java/com/hambug/Hambug/domain/report/repository/CustomReportRepository.java
@@ -1,0 +1,12 @@
+package com.hambug.Hambug.domain.report.repository;
+
+import com.hambug.Hambug.domain.admin.dto.AdminReportResponseDto;
+import com.hambug.Hambug.domain.report.entity.TargetType;
+import com.hambug.Hambug.global.util.PageParams;
+import org.springframework.data.domain.Slice;
+
+public interface CustomReportRepository {
+    Slice<AdminReportResponseDto.ReportGroupSummary> fetchGroupedSliceByTargetType(TargetType targetType, PageParams params);
+
+    Slice<AdminReportResponseDto.ReportDetail> getReportSlice(Long id, PageParams params);
+}

--- a/src/main/java/com/hambug/Hambug/domain/report/repository/CustomReportRepositoryImpl.java
+++ b/src/main/java/com/hambug/Hambug/domain/report/repository/CustomReportRepositoryImpl.java
@@ -1,0 +1,150 @@
+package com.hambug.Hambug.domain.report.repository;
+
+import com.hambug.Hambug.domain.admin.dto.AdminReportResponseDto;
+import com.hambug.Hambug.domain.report.entity.QReport;
+import com.hambug.Hambug.domain.report.entity.TargetType;
+import com.hambug.Hambug.domain.user.entity.QUser;
+import com.hambug.Hambug.global.util.PageParams;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.Tuple;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.core.types.dsl.NumberPath;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.hambug.Hambug.domain.admin.dto.AdminReportResponseDto.ReportGroupSummary;
+
+@Repository
+@RequiredArgsConstructor
+@Slf4j
+public class CustomReportRepositoryImpl implements CustomReportRepository {
+
+    private final JPAQueryFactory factory;
+
+    @Override
+    public Slice<ReportGroupSummary> fetchGroupedSliceByTargetType(TargetType targetType, PageParams params) {
+        QReport r = QReport.report;
+
+        PaginationContext page = getPaginationContext(params);
+
+        BooleanBuilder where = new BooleanBuilder();
+        if (targetType != null) {
+            where.and(r.targetType.eq(targetType));
+        }
+
+        NumberExpression<Long> maxId = r.id.max();
+
+        BooleanBuilder having = new BooleanBuilder();
+        if (page.lastId != null) {
+            if (page.isAsc()) {
+                having.and(maxId.gt(page.lastId));
+            } else {
+                having.and(maxId.lt(page.lastId));
+            }
+        }
+
+        List<Tuple> tuples = factory
+                .select(r.targetId, r.targetType, maxId, r.id.count())
+                .from(r)
+                .where(where)
+                .groupBy(r.targetId, r.targetType)
+                .having(having)
+                .orderBy(page.orderSpec(maxId))
+                .offset(page.offset)
+                .limit(page.limitPlusOne)
+                .fetch();
+
+        boolean hasNext = tuples.size() > page.limit;
+        List<Tuple> contentTuples = hasNext ? tuples.subList(0, page.limit) : tuples;
+
+        List<ReportGroupSummary> content = contentTuples.stream()
+                .map(t -> new ReportGroupSummary(
+                        t.get(r.targetId),
+                        t.get(r.targetType),
+                        t.get(maxId),
+                        t.get(r.id.count())
+                ))
+                .collect(Collectors.toList());
+
+        return new SliceImpl<>(content, PageRequest.of(0, page.limit), hasNext);
+    }
+
+    @Override
+    public Slice<AdminReportResponseDto.ReportDetail> getReportSlice(Long targetId, PageParams params) {
+        QReport r = QReport.report;
+        QUser u = QUser.user;
+        PaginationContext page = getPaginationContext(params);
+
+        BooleanBuilder where = new BooleanBuilder(r.targetId.eq(targetId));
+
+        if (page.lastId != null) {
+            if (page.isAsc()) {
+                where.and(r.id.gt(page.lastId));
+            } else {
+                where.and(r.id.lt(page.lastId));
+            }
+        }
+
+        List<Tuple> results = factory
+                .select(r.id, r.userId, u.nickname, r.reason, r.createdAt)
+                .from(r)
+                .join(u).on(r.userId.eq(u.id))
+                .where(where)
+                .orderBy(page.orderSpec(r.id))
+                .offset(page.offset)
+                .limit(page.limitPlusOne)
+                .fetch();
+
+        boolean hasNext = results.size() > page.limit;
+        List<Tuple> content = hasNext ? results.subList(0, page.limit) : results;
+        List<AdminReportResponseDto.ReportDetail> details = content.stream()
+                .map(t -> new AdminReportResponseDto.ReportDetail(
+                        t.get(r.id),
+                        t.get(r.userId),
+                        t.get(u.nickname),
+                        t.get(r.reason),
+                        t.get(r.createdAt)
+                ))
+                .toList();
+
+        return new SliceImpl<>(details, PageRequest.of(0, page.limit), hasNext);
+    }
+
+    private PaginationContext getPaginationContext(PageParams params) {
+        Long lastId = params != null ? params.lastId() : null;
+        String order = params != null ? params.order() : "DESC";
+        int limit = params != null ? params.limit() : 20;
+        int offset = params != null ? params.offset() : 0;
+        int limitPlusOne = limit + 1;
+        return new PaginationContext(lastId, order, limit, offset, limitPlusOne);
+    }
+
+    private record PaginationContext(
+            Long lastId,
+            String order,
+            int limit,
+            int offset,
+            int limitPlusOne
+    ) {
+        boolean isAsc() {
+            return "ASC".equalsIgnoreCase(order);
+        }
+
+        OrderSpecifier<Long> orderSpec(NumberExpression<Long> column) {
+            return isAsc() ? column.asc() : column.desc();
+        }
+
+        OrderSpecifier<Long> orderSpec(NumberPath<Long> column) {
+            return isAsc() ? column.asc() : column.desc();
+        }
+    }
+}

--- a/src/main/java/com/hambug/Hambug/domain/report/repository/ReportRepository.java
+++ b/src/main/java/com/hambug/Hambug/domain/report/repository/ReportRepository.java
@@ -3,5 +3,5 @@ package com.hambug.Hambug.domain.report.repository;
 import com.hambug.Hambug.domain.report.entity.Report;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ReportRepository extends JpaRepository<Report, Long> {
+public interface ReportRepository extends JpaRepository<Report, Long>, CustomReportRepository {
 }

--- a/src/main/java/com/hambug/Hambug/domain/report/service/ReportService.java
+++ b/src/main/java/com/hambug/Hambug/domain/report/service/ReportService.java
@@ -1,5 +1,6 @@
 package com.hambug.Hambug.domain.report.service;
 
+import com.hambug.Hambug.domain.admin.dto.AdminReportResponseDto;
 import com.hambug.Hambug.domain.board.repository.BoardRepository;
 import com.hambug.Hambug.domain.comment.repository.CommentRepository;
 import com.hambug.Hambug.domain.report.dto.ReportRequestDTO;
@@ -8,7 +9,9 @@ import com.hambug.Hambug.domain.report.entity.TargetType;
 import com.hambug.Hambug.domain.report.repository.ReportRepository;
 import com.hambug.Hambug.global.exception.ErrorCode;
 import com.hambug.Hambug.global.exception.custom.NotFoundException;
+import com.hambug.Hambug.global.util.PageParams;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -34,6 +37,14 @@ public class ReportService {
         reportRepository.save(report);
     }
 
+    public Slice<AdminReportResponseDto.ReportGroupSummary> groupedReportPage(TargetType targetType, PageParams params) {
+        return reportRepository.fetchGroupedSliceByTargetType(targetType, params);
+    }
+
+    public Slice<AdminReportResponseDto.ReportDetail> detailReport(Long id, PageParams pageParams) {
+        return reportRepository.getReportSlice(id, pageParams);
+    }
+
     private void validateTarget(Long targetId, TargetType targetType) {
         switch (targetType) {
             case BOARD -> validateBoard(targetId);
@@ -53,4 +64,6 @@ public class ReportService {
             throw new NotFoundException(ErrorCode.COMMENT_NOT_FOUND);
         }
     }
+
+
 }

--- a/src/main/java/com/hambug/Hambug/domain/user/api/UserApi.java
+++ b/src/main/java/com/hambug/Hambug/domain/user/api/UserApi.java
@@ -19,7 +19,7 @@ import static com.hambug.Hambug.domain.user.dto.UserRequestDto.UpdateUserNicknam
 public interface UserApi {
 
     @Operation(summary = "회원 정보 조회", description = "회원 ID로 회원 정보를 조회합니다.")
-    CommonResponse<UserDto> getUsers(@PathVariable("id") Long id);
+    CommonResponse<UserDto> getUsers(@PathVariable("id") Long id, @AuthenticationPrincipal PrincipalDetails principalDetails);
 
     @Operation(summary = "닉네임 변경", description = "본인 인증을 거친 뒤 닉네임을 변경합니다.")
     CommonResponse<UserDto> updateNickName(@PathVariable("id") Long id,

--- a/src/main/java/com/hambug/Hambug/domain/user/controller/UserController.java
+++ b/src/main/java/com/hambug/Hambug/domain/user/controller/UserController.java
@@ -8,6 +8,7 @@ import com.hambug.Hambug.global.response.CommonResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -22,7 +23,11 @@ public class UserController implements UserApi {
     private final UserService userService;
 
     @GetMapping("/{id}")
-    public CommonResponse<UserDto> getUsers(@PathVariable("id") Long id) {
+    public CommonResponse<UserDto> getUsers(@PathVariable("id") Long id, @AuthenticationPrincipal PrincipalDetails principalDetails) {
+        Long userId = getUserId(principalDetails);
+        if (!id.equals(userId)) {
+            throw new AccessDeniedException("본인 정보만 조회할 수 있습니다.");
+        }
         UserDto userDto = userService.getById(id);
         return CommonResponse.ok(userDto);
     }

--- a/src/main/java/com/hambug/Hambug/domain/user/dto/UserDto.java
+++ b/src/main/java/com/hambug/Hambug/domain/user/dto/UserDto.java
@@ -20,10 +20,6 @@ public class UserDto {
 
     Long userId;
 
-    String email;
-
-    String name;
-
     String nickname;
 
     String profileImageUrl;
@@ -31,6 +27,8 @@ public class UserDto {
     LoginType loginType;
 
     Role role;
+
+    Boolean isRegister;
 
     // 게터에 숨김 적용
     @Getter(onMethod_ = {@JsonIgnore, @Schema(hidden = true)})
@@ -48,13 +46,14 @@ public class UserDto {
     @Getter(onMethod_ = {@JsonIgnore, @Schema(hidden = true)})
     String refreshToken;
 
-    public static UserDto authUserDTO(User user) {
+    public static UserDto authUserDTO(User user, Boolean isRegister) {
         return UserDto.builder()
                 .userId(user.getId())
-                .name(user.getName())
                 .nickname(user.getNickname())
-                .email(user.getEmail())
+                .loginType(user.getLoginType())
+                .profileImageUrl(user.getProfileImageUrl())
                 .role(user.getRole())
+                .isRegister(isRegister)
                 .isActive(user.isActive()).build();
     }
 
@@ -69,11 +68,9 @@ public class UserDto {
     public static UserDto toDto(User user) {
         return UserDto.builder()
                 .userId(user.getId())
-                .name(user.getName())
                 .nickname(user.getNickname())
                 .profileImageUrl(user.getProfileImageUrl())
                 .loginType(user.getLoginType())
-                .email(user.getEmail())
                 .socialId(user.getSocialId())
                 .role(user.getRole())
                 .isActive(user.isActive()).build();

--- a/src/main/java/com/hambug/Hambug/domain/user/entity/User.java
+++ b/src/main/java/com/hambug/Hambug/domain/user/entity/User.java
@@ -24,7 +24,6 @@ public class User extends Timestamped {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private String socialId;
-    private String name;
     @Enumerated(EnumType.STRING)
     private Role role;
 
@@ -32,7 +31,7 @@ public class User extends Timestamped {
     private LoginType loginType;
 
     private String nickname;
-    private String email;
+    
     private String profileImageUrl;
 
     @Enumerated(EnumType.STRING)
@@ -41,9 +40,7 @@ public class User extends Timestamped {
 
     public static User of(Oauth2UserInfo userInfo, String nickname) {
         return User.builder()
-                .email(userInfo.getEmail())
                 .socialId(userInfo.getId())
-                .name(userInfo.getName())
                 .nickname(nickname)
                 .loginType(userInfo.getLoginType())
                 .profileImageUrl("https://s3.ap-northeast-2.amazonaws.com/dev.hambug.com/default_profile.svg")
@@ -56,8 +53,6 @@ public class User extends Timestamped {
     public static User toEntity(UserDto userDto) {
         return User.builder()
                 .id(userDto.getUserId())
-                .email(userDto.getEmail())
-                .name(userDto.getName())
                 .loginType(userDto.getLoginType())
                 .role(userDto.getRole())
                 .isActive(userDto.isActive()).build();

--- a/src/main/java/com/hambug/Hambug/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/hambug/Hambug/domain/user/repository/UserRepository.java
@@ -9,10 +9,8 @@ import java.util.Optional;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
-
-    Optional<User> findByEmailAndIsActive(String email, boolean isActive);
-
-    Optional<User> findByEmailAndLoginType(String email, LoginType loginType);
+    
+    Optional<User> findBySocialIdAndLoginType(String email, LoginType loginType);
 
     Optional<User> findByNickname(String nickname);
 }

--- a/src/main/java/com/hambug/Hambug/global/config/AsyncConfig.java
+++ b/src/main/java/com/hambug/Hambug/global/config/AsyncConfig.java
@@ -1,0 +1,23 @@
+package com.hambug.Hambug.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+    @Bean(name = "mailExecutor")
+    public Executor mailExecutor() {
+        ThreadPoolTaskExecutor exec = new ThreadPoolTaskExecutor();
+        exec.setCorePoolSize(2);
+        exec.setMaxPoolSize(10);
+        exec.setQueueCapacity(100);
+        exec.setThreadNamePrefix("mail-");
+        exec.initialize();
+        return exec;
+    }
+}

--- a/src/main/java/com/hambug/Hambug/global/constatns/Security.java
+++ b/src/main/java/com/hambug/Hambug/global/constatns/Security.java
@@ -26,13 +26,13 @@ public class Security {
             "/webjars/**",
             "/health",
             "/actuator",
-            "/admin/api/v1/register",
-            "/admin/api/v1/login",
+            "/admin/api/v1/auth/register",
+            "/admin/api/v1/auth/login",
             "/api/v1/login/*",
             "/login",
             "/login/oauth2/code/**",
-            "/admin/api/v1/send-email",
-            "/admin/api/v1/verification-email"
+            "/admin/api/v1/auth/send-email",
+            "/admin/api/v1/auth/verification-email"
     );
 
     public static final List<String> ONLY_SUPER_ADMIN_URLS = List.of(

--- a/src/main/java/com/hambug/Hambug/global/constatns/Security.java
+++ b/src/main/java/com/hambug/Hambug/global/constatns/Security.java
@@ -30,7 +30,9 @@ public class Security {
             "/admin/api/v1/login",
             "/api/v1/login/*",
             "/login",
-            "/login/oauth2/code/**"
+            "/login/oauth2/code/**",
+            "/admin/api/v1/send-email",
+            "/admin/api/v1/verification-email"
     );
 
     public static final List<String> ONLY_SUPER_ADMIN_URLS = List.of(

--- a/src/main/java/com/hambug/Hambug/global/email/SmtpEmailService.java
+++ b/src/main/java/com/hambug/Hambug/global/email/SmtpEmailService.java
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
 import java.nio.charset.StandardCharsets;
@@ -24,8 +25,10 @@ public class SmtpEmailService implements EmailService {
     private String from;
 
     @Override
+    @Async("mailExecutor")
     public void sendEmail(EmailMessage message) {
         try {
+            log.info("에에에ㅔㅇ?");
             MimeMessage mime = mailSender.createMimeMessage();
             MimeMessageHelper helper = new MimeMessageHelper(mime, true, StandardCharsets.UTF_8.name());
             helper.setFrom(from);
@@ -38,6 +41,7 @@ public class SmtpEmailService implements EmailService {
             }
             helper.setSubject(message.getSubject());
             helper.setText(message.getBody(), message.isHtml());
+            log.info("여기까지는 오는거지?");
             mailSender.send(mime);
         } catch (MessagingException e) {
             log.error("[EMAIL][SMTP] MessagingException while sending email: {}", e.getMessage(), e);

--- a/src/main/java/com/hambug/Hambug/global/util/PageParams.java
+++ b/src/main/java/com/hambug/Hambug/global/util/PageParams.java
@@ -1,0 +1,53 @@
+package com.hambug.Hambug.global.util;
+
+import lombok.Setter;
+
+/**
+ * Reusable pagination parameters with sane defaults and normalization.
+ * Compose this in any request DTO to avoid re-implementing pagination logic.
+ */
+@Setter
+public class PageParams implements PageQueryUtil {
+
+    private static final int DEFAULT_LIMIT = 20;
+    private static final int MAX_LIMIT = 100;
+    private static final int DEFAULT_OFFSET = 0;
+    private static final String DEFAULT_ORDER = "DESC";
+    private Integer pageLimit;   // nullable in payload
+    private Integer pageOffset;  // nullable in payload
+    private Long lastId;         // nullable in payload
+    private String sortOrder;    // ASC or DESC (case-insensitive), nullable in payload
+    public PageParams() {
+    }
+    public PageParams(Integer pageLimit, Integer pageOffset, Long lastId, String sortOrder) {
+        this.pageLimit = pageLimit;
+        this.pageOffset = pageOffset;
+        this.lastId = lastId;
+        this.sortOrder = sortOrder;
+    }
+
+    @Override
+    public int limit() {
+        int l = pageLimit == null ? DEFAULT_LIMIT : pageLimit;
+        if (l < 1) l = DEFAULT_LIMIT;
+        if (l > MAX_LIMIT) l = MAX_LIMIT;
+        return l;
+    }
+
+    @Override
+    public int offset() {
+        int o = pageOffset == null ? DEFAULT_OFFSET : pageOffset;
+        return Math.max(o, 0);
+    }
+
+    @Override
+    public Long lastId() {
+        return lastId;
+    }
+
+    @Override
+    public String order() {
+        String ord = sortOrder == null ? DEFAULT_ORDER : sortOrder;
+        return ("ASC".equalsIgnoreCase(ord)) ? "ASC" : "DESC";
+    }
+}

--- a/src/main/java/com/hambug/Hambug/global/util/PageQueryUtil.java
+++ b/src/main/java/com/hambug/Hambug/global/util/PageQueryUtil.java
@@ -1,0 +1,11 @@
+package com.hambug.Hambug.global.util;
+
+public interface PageQueryUtil {
+    int limit();
+
+    int offset();
+
+    Long lastId();
+
+    String order();
+}


### PR DESCRIPTION
### 요약
- 최상위 어드민(Onwer) 가입 및 매니저 어드민 초대/가입 흐름 추가
- 이메일 인증 및 비밀번호 재설정 기능 도입
- 신고 내역 목록/상세/삭제 API 추가 및 페이지네이션 지원
- 소셜 로그인 리팩토링: OAuth2 응답으로부터 name/email 저장 제거, 회원가입/로그인 구분을 위한 UserDto 필드 추가

### 주요 변경 사항
#### 1) 어드민/인증
- 최상위 어드민 회원가입 기능 추가
- 최상위 어드민이 매니저 어드민을 등록(회원가입 API)할 수 있도록 추가
- 이메일 인증(Email Verification) API 추가
- 비밀번호 재설정(Reset Password) 기능 추가

#### 2) 신고 관리
- 신고된 내역 무한 페이지네이션 조회 API 추가
  - type=1(Board), type=2(Comment) 구분 지원
- 신고된 타깃 상세 조회 시 신고 사유(reason) 리스트 조회 가능
- 신고된 게시글/댓글 삭제 API 추가

#### 3) 소셜 로그인 리팩토링
- OAuth2 응답 수신 시 사용자 엔티티에서 name, email 컬럼 제거(저장하지 않음)
- 회원가입/로그인 흐름 구분을 위해 UserDto에 isRegister 필드 추가
